### PR TITLE
Convert usage to unique pointers

### DIFF
--- a/Agate/src/Agate/Core/EntryPoint.cpp
+++ b/Agate/src/Agate/Core/EntryPoint.cpp
@@ -75,20 +75,20 @@ bool Agate::EntryPoint::OnWindowClose(WindowCloseEvent &e) {
     return true;
 }
 
-void Agate::EntryPoint::EmplaceLayer(Layer *layer) {
-    m_layerStack.AddLayer(layer);
+void Agate::EntryPoint::EmplaceLayer(std::unique_ptr<Layer> layer) {
+    m_layerStack.AddLayer(std::move(layer));
 }
 
-void Agate::EntryPoint::RemoveLayer(Layer *layer) {
-    m_layerStack.RemoveLayer(layer);
+void Agate::EntryPoint::RemoveLayer(std::unique_ptr<Layer> layer) {
+    m_layerStack.RemoveLayer(std::move(layer));
 }
 
-void Agate::EntryPoint::EmplaceOverlay(Layer *overlay) {
-    m_layerStack.AddOverlay(overlay);
+void Agate::EntryPoint::EmplaceOverlay(std::unique_ptr<Layer> overlay) {
+    m_layerStack.AddOverlay(std::move(overlay));
 }
 
-void Agate::EntryPoint::RemoveOverlay(Layer *overlay) {
-    m_layerStack.RemoveOverlay(overlay);
+void Agate::EntryPoint::RemoveOverlay(std::unique_ptr<Layer> overlay) {
+    m_layerStack.RemoveOverlay(std::move(overlay));
 }
 
 Agate::EntryPoint *&Agate::EntryPoint::GetInstance() {

--- a/Agate/src/Agate/Core/EntryPoint.cpp
+++ b/Agate/src/Agate/Core/EntryPoint.cpp
@@ -75,20 +75,20 @@ bool Agate::EntryPoint::OnWindowClose(WindowCloseEvent &e) {
     return true;
 }
 
-void Agate::EntryPoint::EmplaceLayer(std::unique_ptr<Layer> layer) {
+void Agate::EntryPoint::EmplaceLayer(std::shared_ptr<Layer> layer) {
     m_layerStack.AddLayer(std::move(layer));
 }
 
-void Agate::EntryPoint::RemoveLayer(std::unique_ptr<Layer> layer) {
-    m_layerStack.RemoveLayer(std::move(layer));
+void Agate::EntryPoint::RemoveLayer(const std::shared_ptr<Layer> &layer) {
+    m_layerStack.RemoveLayer(layer);
 }
 
-void Agate::EntryPoint::EmplaceOverlay(std::unique_ptr<Layer> overlay) {
+void Agate::EntryPoint::EmplaceOverlay(std::shared_ptr<Layer> overlay) {
     m_layerStack.AddOverlay(std::move(overlay));
 }
 
-void Agate::EntryPoint::RemoveOverlay(std::unique_ptr<Layer> overlay) {
-    m_layerStack.RemoveOverlay(std::move(overlay));
+void Agate::EntryPoint::RemoveOverlay(const std::shared_ptr<Layer> &overlay) {
+    m_layerStack.RemoveOverlay(overlay);
 }
 
 Agate::EntryPoint *&Agate::EntryPoint::GetInstance() {

--- a/Agate/src/Agate/Core/EntryPoint.cpp
+++ b/Agate/src/Agate/Core/EntryPoint.cpp
@@ -79,16 +79,16 @@ void Agate::EntryPoint::EmplaceLayer(std::shared_ptr<Layer> layer) {
     m_layerStack.AddLayer(std::move(layer));
 }
 
-void Agate::EntryPoint::RemoveLayer(const std::shared_ptr<Layer> &layer) {
-    m_layerStack.RemoveLayer(layer);
+void Agate::EntryPoint::RemoveLayer(std::shared_ptr<Layer> layer) {
+    m_layerStack.RemoveLayer(std::move(layer));
 }
 
 void Agate::EntryPoint::EmplaceOverlay(std::shared_ptr<Layer> overlay) {
     m_layerStack.AddOverlay(std::move(overlay));
 }
 
-void Agate::EntryPoint::RemoveOverlay(const std::shared_ptr<Layer> &overlay) {
-    m_layerStack.RemoveOverlay(overlay);
+void Agate::EntryPoint::RemoveOverlay(std::shared_ptr<Layer> overlay) {
+    m_layerStack.RemoveOverlay(std::move(overlay));
 }
 
 Agate::EntryPoint *&Agate::EntryPoint::GetInstance() {

--- a/Agate/src/Agate/Core/EntryPoint.h
+++ b/Agate/src/Agate/Core/EntryPoint.h
@@ -19,13 +19,13 @@ namespace Agate {
 
         bool OnWindowClose(WindowCloseEvent &e);
 
-        void EmplaceLayer(Layer *layer);
+        void EmplaceLayer(std::unique_ptr<Layer> layer);
 
-        void RemoveLayer(Layer *layer);
+        void RemoveLayer(std::unique_ptr<Layer> layer);
 
-        void EmplaceOverlay(Layer *overlay);
+        void EmplaceOverlay(std::unique_ptr<Layer> overlay);
 
-        void RemoveOverlay(Layer *overlay);
+        void RemoveOverlay(std::unique_ptr<Layer> overlay);
 
         float GetDeltaTime();
 

--- a/Agate/src/Agate/Core/EntryPoint.h
+++ b/Agate/src/Agate/Core/EntryPoint.h
@@ -19,13 +19,13 @@ namespace Agate {
 
         bool OnWindowClose(WindowCloseEvent &e);
 
-        void EmplaceLayer(std::unique_ptr<Layer> layer);
+        void EmplaceLayer(std::shared_ptr<Layer> layer);
 
-        void RemoveLayer(std::unique_ptr<Layer> layer);
+        void RemoveLayer(const std::shared_ptr<Layer> &layer);
 
-        void EmplaceOverlay(std::unique_ptr<Layer> overlay);
+        void EmplaceOverlay(std::shared_ptr<Layer> overlay);
 
-        void RemoveOverlay(std::unique_ptr<Layer> overlay);
+        void RemoveOverlay(const std::shared_ptr<Layer> &overlay);
 
         float GetDeltaTime();
 

--- a/Agate/src/Agate/Core/EntryPoint.h
+++ b/Agate/src/Agate/Core/EntryPoint.h
@@ -21,11 +21,11 @@ namespace Agate {
 
         void EmplaceLayer(std::shared_ptr<Layer> layer);
 
-        void RemoveLayer(const std::shared_ptr<Layer> &layer);
+        void RemoveLayer(std::shared_ptr<Layer> layer);
 
         void EmplaceOverlay(std::shared_ptr<Layer> overlay);
 
-        void RemoveOverlay(const std::shared_ptr<Layer> &overlay);
+        void RemoveOverlay(std::shared_ptr<Layer> overlay);
 
         float GetDeltaTime();
 

--- a/Agate/src/Agate/Core/LayerStack.cpp
+++ b/Agate/src/Agate/Core/LayerStack.cpp
@@ -5,37 +5,35 @@
 Agate::LayerStack::~LayerStack() {
     for (size_t i{0}; i < m_layers.size(); i++) {
         m_layers.at(i)->Detach();
-        delete m_layers.at(i);
         m_layers.erase(m_layers.begin() + i);
     }
 }
 
-void Agate::LayerStack::AddLayer(Layer *layer) {
-    m_layers.emplace(m_layers.begin() + m_amountOfLayers, layer);
-    m_amountOfLayers++;
+void Agate::LayerStack::AddLayer(std::unique_ptr<Layer> layer) {
     layer->Attach();
+    m_layers.emplace(m_layers.begin() + m_amountOfLayers, std::move(layer));
+    m_amountOfLayers++;
 }
 
-void Agate::LayerStack::RemoveLayer(Layer *layer) {
+void Agate::LayerStack::RemoveLayer(std::unique_ptr<Layer> layer) {
     for (size_t i{0}; i < m_layers.size(); i++) {
         if (layer == m_layers.at(i)) {
             layer->Detach();
-            delete layer;
             m_layers.erase(m_layers.begin() + i);
+            break;
         }
     }
 }
 
-void Agate::LayerStack::AddOverlay(Layer *overlay) {
-    m_layers.push_back(overlay);
+void Agate::LayerStack::AddOverlay(std::unique_ptr<Layer> overlay) {
     overlay->Attach();
+    m_layers.push_back(std::move(overlay));
 }
 
-void Agate::LayerStack::RemoveOverlay(Layer *overlay) {
+void Agate::LayerStack::RemoveOverlay(std::unique_ptr<Layer> overlay) {
     for (size_t i{m_layers.size()}; i >= 0; i--) {
         if (overlay == m_layers.at(i)) {
             overlay->Detach();
-            delete overlay;
             m_layers.erase(m_layers.begin() + (m_layers.size() - i));
         }
     }

--- a/Agate/src/Agate/Core/LayerStack.cpp
+++ b/Agate/src/Agate/Core/LayerStack.cpp
@@ -15,7 +15,7 @@ void Agate::LayerStack::AddLayer(std::shared_ptr<Layer> layer) {
     m_amountOfLayers++;
 }
 
-void Agate::LayerStack::RemoveLayer(const std::shared_ptr<Layer> &layer) {
+void Agate::LayerStack::RemoveLayer(std::shared_ptr<Layer> layer) {
     for (size_t i{0}; i < m_layers.size(); i++) {
         if (layer == m_layers.at(i)) {
             layer->Detach();
@@ -30,7 +30,7 @@ void Agate::LayerStack::AddOverlay(std::shared_ptr<Layer> overlay) {
     m_layers.push_back(std::move(overlay));
 }
 
-void Agate::LayerStack::RemoveOverlay(const std::shared_ptr<Layer> &overlay) {
+void Agate::LayerStack::RemoveOverlay(std::shared_ptr<Layer> overlay) {
     for (size_t i{m_layers.size()}; i >= 0; i--) {
         if (overlay == m_layers.at(i)) {
             overlay->Detach();

--- a/Agate/src/Agate/Core/LayerStack.cpp
+++ b/Agate/src/Agate/Core/LayerStack.cpp
@@ -9,13 +9,13 @@ Agate::LayerStack::~LayerStack() {
     }
 }
 
-void Agate::LayerStack::AddLayer(std::unique_ptr<Layer> layer) {
+void Agate::LayerStack::AddLayer(std::shared_ptr<Layer> layer) {
     layer->Attach();
     m_layers.emplace(m_layers.begin() + m_amountOfLayers, std::move(layer));
     m_amountOfLayers++;
 }
 
-void Agate::LayerStack::RemoveLayer(std::unique_ptr<Layer> layer) {
+void Agate::LayerStack::RemoveLayer(const std::shared_ptr<Layer> &layer) {
     for (size_t i{0}; i < m_layers.size(); i++) {
         if (layer == m_layers.at(i)) {
             layer->Detach();
@@ -25,16 +25,17 @@ void Agate::LayerStack::RemoveLayer(std::unique_ptr<Layer> layer) {
     }
 }
 
-void Agate::LayerStack::AddOverlay(std::unique_ptr<Layer> overlay) {
+void Agate::LayerStack::AddOverlay(std::shared_ptr<Layer> overlay) {
     overlay->Attach();
     m_layers.push_back(std::move(overlay));
 }
 
-void Agate::LayerStack::RemoveOverlay(std::unique_ptr<Layer> overlay) {
+void Agate::LayerStack::RemoveOverlay(const std::shared_ptr<Layer> &overlay) {
     for (size_t i{m_layers.size()}; i >= 0; i--) {
         if (overlay == m_layers.at(i)) {
             overlay->Detach();
             m_layers.erase(m_layers.begin() + (m_layers.size() - i));
+            break;
         }
     }
 }

--- a/Agate/src/Agate/Core/LayerStack.h
+++ b/Agate/src/Agate/Core/LayerStack.h
@@ -17,20 +17,20 @@ namespace Agate {
          * Adds layer to the end of the layer stack but before overlay layers
          * @param layer
          */
-        virtual void AddLayer(std::unique_ptr<Layer> layer);
+        virtual void AddLayer(std::shared_ptr<Layer> layer);
 
-        virtual void RemoveLayer(std::unique_ptr<Layer> layer);
+        virtual void RemoveLayer(const std::shared_ptr<Layer> &layer);
 
         /**
          * adds an overlay layer, overlay layers are the last to be rendered
          * @param overlay
          */
-        virtual void AddOverlay(std::unique_ptr<Layer> overlay);
+        virtual void AddOverlay(std::shared_ptr<Layer> overlay);
 
-        virtual void RemoveOverlay(std::unique_ptr<Layer> overlay);
+        virtual void RemoveOverlay(const std::shared_ptr<Layer> &overlay);
 
     private:
-        std::vector<std::unique_ptr<Layer>> m_layers;
+        std::vector<std::shared_ptr<Layer>> m_layers;
         unsigned int m_amountOfLayers = 0;
     };
 }// namespace Agate

--- a/Agate/src/Agate/Core/LayerStack.h
+++ b/Agate/src/Agate/Core/LayerStack.h
@@ -4,7 +4,6 @@
 
 #include "Layer.h"
 
-
 namespace Agate {
     class LayerStack {
         friend class EntryPoint;
@@ -18,20 +17,20 @@ namespace Agate {
          * Adds layer to the end of the layer stack but before overlay layers
          * @param layer
          */
-        virtual void AddLayer(Layer *layer);
+        virtual void AddLayer(std::unique_ptr<Layer> layer);
 
-        virtual void RemoveLayer(Layer *layer);
+        virtual void RemoveLayer(std::unique_ptr<Layer> layer);
 
         /**
          * adds an overlay layer, overlay layers are the last to be rendered
          * @param overlay
          */
-        virtual void AddOverlay(Layer *overlay);
+        virtual void AddOverlay(std::unique_ptr<Layer> overlay);
 
-        virtual void RemoveOverlay(Layer *overlay);
+        virtual void RemoveOverlay(std::unique_ptr<Layer> overlay);
 
     private:
-        std::vector<Layer *> m_layers;
+        std::vector<std::unique_ptr<Layer>> m_layers;
         unsigned int m_amountOfLayers = 0;
     };
 }// namespace Agate

--- a/Agate/src/Agate/Core/LayerStack.h
+++ b/Agate/src/Agate/Core/LayerStack.h
@@ -19,7 +19,7 @@ namespace Agate {
          */
         virtual void AddLayer(std::shared_ptr<Layer> layer);
 
-        virtual void RemoveLayer(const std::shared_ptr<Layer> &layer);
+        virtual void RemoveLayer(std::shared_ptr<Layer> layer);
 
         /**
          * adds an overlay layer, overlay layers are the last to be rendered
@@ -27,7 +27,7 @@ namespace Agate {
          */
         virtual void AddOverlay(std::shared_ptr<Layer> overlay);
 
-        virtual void RemoveOverlay(const std::shared_ptr<Layer> &overlay);
+        virtual void RemoveOverlay(std::shared_ptr<Layer> overlay);
 
     private:
         std::vector<std::shared_ptr<Layer>> m_layers;

--- a/Application/src/Application.cpp
+++ b/Application/src/Application.cpp
@@ -1,6 +1,7 @@
 
 #include "Agate.h"
 #include <iostream>
+#include <memory>
 #include <string>
 #include <filesystem>
 class app : public Agate::EntryPoint {
@@ -72,8 +73,8 @@ Agate::EntryPoint *Agate::CreateEntryPoint()
 {
     auto Application = new app();
 
-    Application->EmplaceLayer(new layerEx);
-    Application->EmplaceLayer(new TemplayerEx);
+    Application->EmplaceLayer(std::make_unique<layerEx>());
+    Application->EmplaceLayer(std::make_unique<TemplayerEx>());
 
     return Application;
 }

--- a/Application/src/Application.cpp
+++ b/Application/src/Application.cpp
@@ -1,8 +1,6 @@
 
 #include "Agate.h"
-#include <iostream>
 #include <memory>
-#include <string>
 #include <filesystem>
 class app : public Agate::EntryPoint {
 
@@ -18,9 +16,13 @@ public:
 
     void Detach() override
     {
+        PRINTMSG("Detach example layer");
     }
-    void OnRender()override {
+
+    void OnRender()override
+    {
     };
+
     void OnEvent(Agate::Event &e) override
     {
     }
@@ -42,6 +44,7 @@ public:
 
     void Detach() override
     {
+
     }
 
     void OnRender() override
@@ -73,8 +76,12 @@ Agate::EntryPoint *Agate::CreateEntryPoint()
 {
     auto Application = new app();
 
-    Application->EmplaceLayer(std::make_unique<layerEx>());
-    Application->EmplaceLayer(std::make_unique<TemplayerEx>());
+    std::shared_ptr<layerEx> example_layer = std::make_shared<layerEx>();
+
+    Application->EmplaceLayer(example_layer);
+    Application->EmplaceLayer(std::make_shared<TemplayerEx>());
+
+    Application->RemoveLayer(example_layer);
 
     return Application;
 }


### PR DESCRIPTION
It is safer to use shared pointers here rather then manually deleting and managing layers.