### PR TITLE
Add doxygen-style comments and standardize include guards

### DIFF
--- a/Agate/src/Agate/Core/Core.h
+++ b/Agate/src/Agate/Core/Core.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef AGATE_CORE_H
+#define AGATE_CORE_H
 
 #ifdef Agate_STATIC
 #define API
@@ -11,3 +12,5 @@
 #endif
 
 #define BindFn(x) std::bind(&x, this, std::placeholders::_1)
+
+#endif // AGATE_CORE_H

--- a/Agate/src/Agate/Core/Core.h
+++ b/Agate/src/Agate/Core/Core.h
@@ -1,3 +1,8 @@
+/**
+ * @brief Adds macros based on whether the engine should declare
+ *        dynamic exports as well as a binding macro
+ */
+
 #ifndef AGATE_CORE_H
 #define AGATE_CORE_H
 

--- a/Agate/src/Agate/Core/EntryPoint.h
+++ b/Agate/src/Agate/Core/EntryPoint.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef AGATE_ENTRYPOINT_H
+#define AGATE_ENTRYPOINT_H
 
 #include "Agate/Events/ApplicationEvents.h"
 #include "Agate/Events/Event.h"
@@ -115,3 +116,5 @@ namespace Agate {
     EntryPoint *CreateEntryPoint();
 
 }// namespace Agate
+
+#endif // AGATE_ENTRYPOINT_H

--- a/Agate/src/Agate/Core/EntryPoint.h
+++ b/Agate/src/Agate/Core/EntryPoint.h
@@ -1,3 +1,8 @@
+/**
+ * @brief Include file for the EntryPoint class and CreateEntryPoint
+ *        free function stub. Consuming applications should start here
+ */
+
 #ifndef AGATE_ENTRYPOINT_H
 #define AGATE_ENTRYPOINT_H
 

--- a/Agate/src/Agate/Core/EntryPoint.h
+++ b/Agate/src/Agate/Core/EntryPoint.h
@@ -7,30 +7,90 @@
 #include "LayerStack.h"
 
 namespace Agate {
+
+    /**
+     * @brief Manages the layer stack, windowing and
+     *        event systems while running the core loop
+     *        for the engine
+     */
     class API EntryPoint {
     public:
         EntryPoint();
 
         virtual ~EntryPoint();
 
+        /**
+         * @brief Begins the core render loop
+         */
         void Run();
 
+        /**
+         * @brief Passes an event down the layer stack for
+         *        each layer to respond to, until the event
+         *        is tagged as handled
+         * 
+         * @param e Event to pass
+         */
         void OnEvent(Event &e);
 
+        /**
+         * @brief Special event handler for WindowCloseEvent
+         * 
+         * @param e Triggering event
+         * 
+         * @return True
+         */
         bool OnWindowClose(WindowCloseEvent &e);
 
+        /**
+         * @brief Inserts a layer in front of the first overlay
+         *        layer in the stack
+         * 
+         * @param layer Layer to insert
+         */
         void EmplaceLayer(Layer *layer);
 
+        /**
+         * @brief Removes a layer from the stack
+         * 
+         * @param layer Layer to remove
+         */
         void RemoveLayer(Layer *layer);
 
+        /**
+         * @brief Appends an overlay layer to the end of the
+         *        stack
+         * 
+         * @param overlay Layer to append
+         */
         void EmplaceOverlay(Layer *overlay);
 
+        /**
+         * @brief Removes an overlay layer from the stack
+         * 
+         * @param overlay Layer to remove
+         */
         void RemoveOverlay(Layer *overlay);
 
+        /**
+         * @brief Time elapsed rendering the most recent frame
+         *        in seconds
+         * 
+         * @return Number of seconds that have elapsed
+         */
         float GetDeltaTime();
 
+        /**
+         * @brief Accessor for the main window managed by
+         *        this instance
+         * 
+         * @return Shared pointer to the main window
+         */
         std::shared_ptr<Agate::Window> GetWindow();
 
+        /**
+         * @brief Accessor to the singleton instance
+         */
         static EntryPoint *&GetInstance();
 
     private:
@@ -43,7 +103,15 @@ namespace Agate {
         static EntryPoint *s_instance;
     };
 
-    //to be defined outside of lib
+    /**
+     * @warning Intentionally undefined - Consuming
+     * applications must define this function 
+     * to instantiate an entry for the engine
+     * to run.
+     * 
+     * @brief Instantiates an application for the
+     * engine to run
+     */
     EntryPoint *CreateEntryPoint();
 
 }// namespace Agate

--- a/Agate/src/Agate/Core/InputPulling.h
+++ b/Agate/src/Agate/Core/InputPulling.h
@@ -7,12 +7,34 @@
 
 #include "Agate/Core/keyCodes.h"
 
+/**
+ * @brief Provides static accessors to read the state
+ *        of inputs
+ */
 class InputPulling {
 public:
+
+    /**
+     * @brief Reads the input status of the specified key
+     * 
+     * @param keycode Code for target key
+     * 
+     * @return True if target key is pressed
+     */
     static bool IsKeyPressed(unsigned int keycode);
 
+    /**
+     * @brief Reads the X coordinate of the mouse
+     * 
+     * @return X coordinate of the mouse position
+     */
     static double GetXMousePos();
 
+    /**
+     * @brief Reads the Y coordinate of the mouse
+     * 
+     * @return Y coordinate of the mouse position
+     */
     static double GetYMousePos();
 
 private:

--- a/Agate/src/Agate/Core/InputPulling.h
+++ b/Agate/src/Agate/Core/InputPulling.h
@@ -1,6 +1,9 @@
-//
-// Created by william on 11/3/22.
-//
+/**
+ * @brief Include file for the InputPulling class. Provides
+ *        read access for keyboard and mouse inputs
+ * 
+ * Created by william on 11/3/22.
+ */
 
 #ifndef AGATE_INPUTPULLING_H
 #define AGATE_INPUTPULLING_H
@@ -41,5 +44,4 @@ private:
     InputPulling();
 };
 
-
-#endif//AGATE_INPUTPULLING_H
+#endif // AGATE_INPUTPULLING_H

--- a/Agate/src/Agate/Core/Layer.h
+++ b/Agate/src/Agate/Core/Layer.h
@@ -3,14 +3,35 @@
 #include "Agate/Events/Event.h"
 
 namespace Agate {
+
+    /**
+     * @brief Base class for all layers
+     */
     class Layer {
     public:
+
+        /**
+         * @brief Called immediately after being added to the 
+         *        layer stack
+         */
         virtual void Attach() {}
 
+        /**
+         * @brief Called immediately before being removed from
+         *        the layer stack
+         */
         virtual void Detach() {}
 
+        /**
+         * @brief Event handler for this layer
+         * 
+         * @param e Event to handle
+         */
         virtual void OnEvent(Event &e) {}
 
+        /**
+         * @brief Called once every render frame
+         */
         virtual void OnRender() {};
 
     private:

--- a/Agate/src/Agate/Core/Layer.h
+++ b/Agate/src/Agate/Core/Layer.h
@@ -4,7 +4,8 @@
  *        loop
  */
 
-#pragma once
+#ifndef AGATE_LAYER_H
+#define AGATE_LAYER_H
 
 #include "Agate/Events/Event.h"
 
@@ -44,3 +45,5 @@ namespace Agate {
         bool m_Enabled = true;
     };
 }// namespace Agate
+
+#endif // AGATE_LAYER_H

--- a/Agate/src/Agate/Core/Layer.h
+++ b/Agate/src/Agate/Core/Layer.h
@@ -1,3 +1,9 @@
+/**
+ * @brief Include file for the Layer class. Layers are used to
+ *        separate and order operations and events in the core
+ *        loop
+ */
+
 #pragma once
 
 #include "Agate/Events/Event.h"

--- a/Agate/src/Agate/Core/LayerStack.h
+++ b/Agate/src/Agate/Core/LayerStack.h
@@ -3,7 +3,8 @@
  *        core loop to organize layers
  */
 
-#pragma once
+#ifndef AGATE_LAYERSTACK_H
+#define AGATE_LAYERSTACK_H
 
 #include "agpch.h"
 
@@ -59,3 +60,5 @@ namespace Agate {
         unsigned int m_amountOfLayers = 0;
     };
 }// namespace Agate
+
+#endif // AGATE_LAYERSTACK_H

--- a/Agate/src/Agate/Core/LayerStack.h
+++ b/Agate/src/Agate/Core/LayerStack.h
@@ -6,6 +6,13 @@
 
 
 namespace Agate {
+
+    /**
+     * @brief Holds an ordering of layers accessible only by the
+     *        core loop and event system
+     * 
+     * @note See Agate::EntryPoint
+     */
     class LayerStack {
         friend class EntryPoint;
 
@@ -15,19 +22,31 @@ namespace Agate {
         ~LayerStack();
 
         /**
-         * Adds layer to the end of the layer stack but before overlay layers
-         * @param layer
+         * @brief Adds a layer to the end of the layer stack but before overlay layers
+         * 
+         * @param layer Layer to add
          */
         virtual void AddLayer(Layer *layer);
 
+        /**
+         * @brief Removes a layer from the stack
+         * 
+         * @param layer Layer to remove
+         */
         virtual void RemoveLayer(Layer *layer);
 
         /**
-         * adds an overlay layer, overlay layers are the last to be rendered
-         * @param overlay
+         * @brief Adds an overlay layer, overlay layers are the last to be rendered
+         * 
+         * @param overlay Layer to add
          */
         virtual void AddOverlay(Layer *overlay);
 
+        /**
+         * @brief Removes an overlay layer from the stack
+         * 
+         * @param overlay Layer to remove
+         */
         virtual void RemoveOverlay(Layer *overlay);
 
     private:

--- a/Agate/src/Agate/Core/LayerStack.h
+++ b/Agate/src/Agate/Core/LayerStack.h
@@ -1,3 +1,8 @@
+/**
+ * @brief Include file for the LayerStack class. Used by the
+ *        core loop to organize layers
+ */
+
 #pragma once
 
 #include "agpch.h"

--- a/Agate/src/Agate/Core/Logger.h
+++ b/Agate/src/Agate/Core/Logger.h
@@ -5,28 +5,79 @@
 
 namespace Agate {
 
+    /**
+     * @brief Adapter to decouple internal logging from spdlog
+     */
     class Logger {
     public:
+
+        /**
+         * @brief Initializes logging format
+         */
         static void initLogger();
 
+        /**
+         * @brief Logs a message at the info level. For informational messages
+         *        that do not indicate any issue
+         * 
+         * @param file Name of the file creating the log
+         * @param function Name of the function creating the log
+         * @param line Source code line creating the log
+         * @param format Message to log. Supports a base format string
+         * @param args If using a format string, the content to populate format
+         *             markers
+         */
         template<typename... Args>
         static void printMSG(const char *file, const char *function, int line, const char *format, Args &&... args) {
             s_Logger->log(spdlog::source_loc{file, line, function}, spdlog::level::info,
                           fmt::format(format, std::forward<Args>(args)...));
         }
 
+        /**
+         * @brief Logs a message at the warn level. For warnings that are
+         *        unlikely to cause a non-recoverable error
+         * 
+         * @param file Name of the file creating the log
+         * @param function Name of the function creating the log
+         * @param line Source code line creating the log
+         * @param format Message to log. Supports a base format string
+         * @param args If using a format string, the content to populate format
+         *             markers
+         */
         template<typename... Args>
         static void printWarn(const char *file, const char *function, int line, const char *format, Args &&... args) {
             s_Logger->log(spdlog::source_loc{file, line, function}, spdlog::level::warn,
                           fmt::format(format, std::forward<Args>(args)...));
         }
 
+        /**
+         * @brief Logs a message at the info level. For warnings that the
+         *        state of the program is knowingly susceptible to a non-recoverable
+         *        error
+         * 
+         * @param file Name of the file creating the log
+         * @param function Name of the function creating the log
+         * @param line Source code line creating the log
+         * @param format Message to log. Supports a base format string
+         * @param args If using a format string, the content to populate format
+         *             markers
+         */
         template<typename... Args>
         static void printError(const char *file, const char *function, int line, const char *format, Args &&... args) {
             s_Logger->log(spdlog::source_loc{file, line, function}, spdlog::level::err,
                           fmt::format(format, std::forward<Args>(args)...));
         }
 
+        /**
+         * @brief Logs a message at the info level. For non-recoverable errors
+         * 
+         * @param file Name of the file creating the log
+         * @param function Name of the function creating the log
+         * @param line Source code line creating the log
+         * @param format Message to log. Supports a base format string
+         * @param args If using a format string, the content to populate format
+         *             markers
+         */
         template<typename... Args>
         static void printCrit(const char *file, const char *function, int line, const char *format, Args &&... args) {
             s_Logger->log(spdlog::source_loc{file, line, function}, spdlog::level::critical,
@@ -38,8 +89,39 @@ namespace Agate {
     };
 }// namespace Agate
 
-//types of supported logging
+/**
+ * @brief Logs a message at the info level. For informational messages
+ *        that do not indicate any issue
+ * 
+ * @param format Message to log. Supports a base format string
+ * @param args If using a format string, the content to populate format
+ *             markers
+ */
 #define PRINTMSG(format, ...) Agate::Logger::printMSG(__FILE__, __func__, __LINE__, format, ##__VA_ARGS__)
+/**
+ * @brief Logs a message at the warn level. For warnings that are
+ *        unlikely to cause a non-recoverable error
+ * 
+ * @param format Message to log. Supports a base format string
+ * @param args If using a format string, the content to populate format
+ *             markers
+ */
 #define PRINTWARN(format, ...) Agate::Logger::printWarn(__FILE__, __func__, __LINE__, format, ##__VA_ARGS__)
+/**
+ * @brief Logs a message at the info level. For warnings that the
+ *        state of the program is knowingly susceptible to a non-recoverable
+ *        error
+ * 
+ * @param format Message to log. Supports a base format string
+ * @param args If using a format string, the content to populate format
+ *             markers
+ */
 #define PRINTERROR(format, ...) Agate::Logger::printError(__FILE__, __func__, __LINE__, format, ##__VA_ARGS__)
+/**
+ * @brief Logs a message at the info level. For non-recoverable errors
+ * 
+ * @param format Message to log. Supports a base format string
+ * @param args If using a format string, the content to populate format
+ *             markers
+ */
 #define PRINTCRIT(format, ...) Agate::Logger::printCrit(__FILE__, __func__, __LINE__, format, ##__VA_ARGS__)

--- a/Agate/src/Agate/Core/Logger.h
+++ b/Agate/src/Agate/Core/Logger.h
@@ -4,7 +4,8 @@
  *        rest of the codebase from logging dependencies
  */
 
-#pragma once
+#ifndef AGATE_LOGGER_H
+#define AGATE_LOGGER_H
 
 #include "Core.h"
 #include <spdlog/logger.h>
@@ -131,3 +132,5 @@ namespace Agate {
  *             markers
  */
 #define PRINTCRIT(format, ...) Agate::Logger::printCrit(__FILE__, __func__, __LINE__, format, ##__VA_ARGS__)
+
+#endif // AGATE_LOGGER_H

--- a/Agate/src/Agate/Core/Logger.h
+++ b/Agate/src/Agate/Core/Logger.h
@@ -1,3 +1,9 @@
+/**
+ * @brief Include file for the Logger class and logging macros. The
+ *        Logger class serves to decouple logging macros and the
+ *        rest of the codebase from logging dependencies
+ */
+
 #pragma once
 
 #include "Core.h"

--- a/Agate/src/Agate/Core/Main.h
+++ b/Agate/src/Agate/Core/Main.h
@@ -4,7 +4,8 @@
  *        by consuming applications) to run Agate
  */
 
-#pragma once
+#ifndef AGATE_MAIN_H
+#define AGATE_MAIN_H
 
 //-----------------------------------------Main Entry -----------------------------------
 extern Agate::EntryPoint *Agate::CreateEntryPoint();
@@ -19,3 +20,5 @@ int main() {
     return 0;
 }
 //--------------------------------------------------------------------------------------
+
+#endif // AGATE_MAIN_H

--- a/Agate/src/Agate/Core/Main.h
+++ b/Agate/src/Agate/Core/Main.h
@@ -1,3 +1,9 @@
+/**
+ * @brief Include file for running an Agate executable. Defines main
+ *        and utilizes `Agate::CreateEntryPoint` (which must be defined
+ *        by consuming applications) to run Agate
+ */
+
 #pragma once
 
 //-----------------------------------------Main Entry -----------------------------------

--- a/Agate/src/Agate/Core/keyCodes.h
+++ b/Agate/src/Agate/Core/keyCodes.h
@@ -1,6 +1,8 @@
-//
-// Created by william on 11/3/22.
-//
+/**
+ * @brief Provides named symbols that map to keys
+ * 
+ * Created by william on 11/3/22.
+ */
 
 #pragma once
 //from GFLW3.h and modified

--- a/Agate/src/Agate/Core/keyCodes.h
+++ b/Agate/src/Agate/Core/keyCodes.h
@@ -4,7 +4,9 @@
  * Created by william on 11/3/22.
  */
 
-#pragma once
+#ifndef AGATE_KEYCODES_H
+#define AGATE_KEYCODES_H
+
 //from GFLW3.h and modified
 
 #define AGATE_KEY_SPACE 32
@@ -128,3 +130,5 @@
 #define AGATE_KEY_RIGHT_ALT 346
 #define AGATE_KEY_RIGHT_SUPER 347
 #define AGATE_KEY_MENU 348
+
+#endif // AGATE_KEYCODES_H


### PR DESCRIPTION
This PR adds documentation comments to all header definitions in the Core directory. I'm batching PRs for these issues to prevent overloading one PR with every file's doc comments

Progress on #39 and #40