### PR TITLE
Add doxygen-style comments and standardize include guards

### DIFF
--- a/Agate/src/Agate/Events/ApplicationEvents.h
+++ b/Agate/src/Agate/Events/ApplicationEvents.h
@@ -1,3 +1,7 @@
+/**
+ * @brief Include file for application/window level events
+ */
+
 #pragma once
 
 #include "Agate/Events/Event.h"

--- a/Agate/src/Agate/Events/ApplicationEvents.h
+++ b/Agate/src/Agate/Events/ApplicationEvents.h
@@ -2,7 +2,8 @@
  * @brief Include file for application/window level events
  */
 
-#pragma once
+#ifndef AGATE_APPLICATIONEVENTS_H
+#define AGATE_APPLICATIONEVENTS_H
 
 #include "Agate/Events/Event.h"
 
@@ -55,3 +56,5 @@ namespace Agate {
         }
     };
 }// namespace Agate
+
+#endif // AGATE_APPLICATIONEVENTS_H

--- a/Agate/src/Agate/Events/ApplicationEvents.h
+++ b/Agate/src/Agate/Events/ApplicationEvents.h
@@ -8,24 +8,50 @@
 #include "Agate/Events/Event.h"
 
 namespace Agate {
+
+    /**
+     * @brief Emitted when the application window is resized.
+     *        Has the new window size
+     */
     class WindowResizedEvent : public Event {
     public:
+
+        /**
+         * @brief Constructor - takes the new dimensions of
+         *        the window
+         * 
+         * @param x New width of the window
+         * @param y New height of the window
+         */
         WindowResizedEvent(int x, int y)
                 : m_xSize(x), m_ySize(y) {
         }
 
+        /**
+         * @brief Type of this event
+         */
         EventTypes GetEventType() override {
             return EventTypes::WindowResized;
         }
 
+        /**
+         * @brief Prints the name of this event
+         */
         void PrintEventName() override {
             PRINTMSG("Window Resized to: {}, {}", m_xSize, m_ySize);
         }
 
+        /**
+         * @brief Predicate for whether the event has
+         *        been fully handled
+         */
         bool Handled() override {
             return this->EventFinised;
         }
 
+        /**
+         * @brief Type of this event
+         */
         static EventTypes s_GetEventType() {
             return EventTypes::WindowResized;
         }
@@ -34,23 +60,40 @@ namespace Agate {
         int m_xSize, m_ySize;
     };
 
+    /**
+     * @brief Emitted when the application window is closed
+     */
     class WindowCloseEvent : public Event {
     public:
+
         WindowCloseEvent() {
         }
 
+        /**
+         * @brief Type of this event
+         */
         EventTypes GetEventType() override {
             return EventTypes::WindowClose;
         }
 
+        /**
+         * @brief Prints the name of this event
+         */
         void PrintEventName() override {
             PRINTMSG("Window Closing");
         }
 
+        /**
+         * @brief Predicate for whether the event has
+         *        been fully handled
+         */
         bool Handled() override {
             return this->EventFinised;
         }
 
+        /**
+         * @brief Type of this event
+         */
         static EventTypes s_GetEventType() {
             return EventTypes::WindowClose;
         }

--- a/Agate/src/Agate/Events/Event.h
+++ b/Agate/src/Agate/Events/Event.h
@@ -1,3 +1,7 @@
+/**
+ * @brief Include file for base event classes and types
+ */
+
 #pragma once
 
 #include "agpch.h"

--- a/Agate/src/Agate/Events/Event.h
+++ b/Agate/src/Agate/Events/Event.h
@@ -83,7 +83,9 @@ namespace Agate {
          * @param ev Handler for the event, given it is of the
          *           appropriate type
          * 
-         * @return True if the event has been handled by this invocation
+         * @return Whether the event has been handled by this invocation
+         * @retval true The event has been handled
+         * @retval false The event has not been handled
          */
         template<typename T>
         bool NotifyEvent(EventFn<T> ev) {

--- a/Agate/src/Agate/Events/Event.h
+++ b/Agate/src/Agate/Events/Event.h
@@ -10,9 +10,11 @@
 #include "Agate/Core/Core.h"
 #include "Agate/Core/Logger.h"
 
-
 namespace Agate {
 
+    /**
+     * @brief Built-in event types for the engine
+     */
     enum class API EventTypes {
         MouseButtonPressed,
         MouseButtonReleased,
@@ -24,6 +26,9 @@ namespace Agate {
 
     };
 
+    /**
+     * @brief Base virtual class for engine events. 
+     */
     class API Event {
         friend class EventNotifier;
 
@@ -31,26 +36,56 @@ namespace Agate {
         Event()
                 : EventFinised(false) {}
 
+        /**
+         * @brief Type of this event
+         */
         virtual EventTypes GetEventType() = 0;
 
+        /**
+         * @brief Prints the name of this event
+         */
         virtual void PrintEventName() = 0;
 
+        /**
+         * @brief Predicate for whether the event has
+         *        been fully handled
+         */
         virtual bool Handled() = 0;
 
     protected:
         bool EventFinised;
     };
 
+    /**
+     * @brief Wrapper for event handlers. Consumes a generic
+     *        `Event` and narrows it to a specialization of
+     *        `Event` if it can handle the event
+     */
     class API EventNotifier {
         template<typename T>
         using EventFn = std::function<bool(T &)>;
 
     public:
+
+        /**
+         * @brief Constructor; Creates a notifier for an event
+         * 
+         * @param e Event to handle
+         */
         explicit EventNotifier(Event &e)
                 : m_Event(e) {};
 
+        /**
+         * @brief Template that conditionally handles the underlying
+         *        event if its event type matches that of the template
+         *        argument
+         * 
+         * @param ev Handler for the event, given it is of the
+         *           appropriate type
+         * 
+         * @return True if the event has been handled by this invocation
+         */
         template<typename T>
-
         bool NotifyEvent(EventFn<T> ev) {
             if (m_Event.GetEventType() == T::s_GetEventType()) {
                 m_Event.EventFinised = ev(*(T *) &m_Event);
@@ -62,7 +97,6 @@ namespace Agate {
     private:
         Event &m_Event;
     };
-
 
 }// namespace Agate
 

--- a/Agate/src/Agate/Events/Event.h
+++ b/Agate/src/Agate/Events/Event.h
@@ -2,7 +2,8 @@
  * @brief Include file for base event classes and types
  */
 
-#pragma once
+#ifndef AGATE_EVENT_H
+#define AGATE_EVENT_H
 
 #include "agpch.h"
 
@@ -64,3 +65,5 @@ namespace Agate {
 
 
 }// namespace Agate
+
+#endif // AGATE_EVENT_H

--- a/Agate/src/Agate/Events/Event.h
+++ b/Agate/src/Agate/Events/Event.h
@@ -59,7 +59,8 @@ namespace Agate {
     /**
      * @brief Wrapper for event handlers. Consumes a generic
      *        `Event` and narrows it to a specialization of
-     *        `Event` if it can handle the event
+     *        `Event` if possible to bind it to a callback
+     *        that is then invoked
      */
     class API EventNotifier {
         template<typename T>

--- a/Agate/src/Agate/Events/KeyEvents.h
+++ b/Agate/src/Agate/Events/KeyEvents.h
@@ -1,7 +1,7 @@
 /**
  * @brief Include file for keyboard input events
  * 
- * Created by TANK1_41 on 8/23/2022.
+ * Created by William on 8/23/2022.
  */
 
 #include "Event.h"

--- a/Agate/src/Agate/Events/KeyEvents.h
+++ b/Agate/src/Agate/Events/KeyEvents.h
@@ -6,7 +6,9 @@
 
 #include "Event.h"
 
-#pragma once
+#ifndef AGATE_KEYEVENTS_H
+#define AGATE_KEYEVENTS_H
+
 namespace Agate {
     class KeyPressedEvent : public Event {
     public:
@@ -65,4 +67,6 @@ namespace Agate {
     private:
         unsigned int m_keycode;
     };
-}// namespace Agate
+} // namespace Agate
+
+#endif // AGATE_KEYEVENTS_H

--- a/Agate/src/Agate/Events/KeyEvents.h
+++ b/Agate/src/Agate/Events/KeyEvents.h
@@ -1,6 +1,9 @@
-//
-// Created by TANK1_41 on 8/23/2022.
-//
+/**
+ * @brief Include file for keyboard input events
+ * 
+ * Created by TANK1_41 on 8/23/2022.
+ */
+
 #include "Event.h"
 
 #pragma once

--- a/Agate/src/Agate/Events/KeyEvents.h
+++ b/Agate/src/Agate/Events/KeyEvents.h
@@ -10,27 +10,56 @@
 #define AGATE_KEYEVENTS_H
 
 namespace Agate {
+
+    /**
+     * @brief Emitted when any key is pressed
+     */
     class KeyPressedEvent : public Event {
     public:
+
+        /**
+         * @brief Constructor - takes a keycode to identify the
+         *        pressed key
+         * 
+         * @param keyCode Keycode representing the pressed key
+         */
         KeyPressedEvent(int keyCode)
                 : m_keycode(keyCode) {};
 
+        /**
+         * @brief Type of this event
+         */
         EventTypes GetEventType() override {
             return EventTypes::KeyPressed;
         }
 
+        /**
+         * @brief Prints the name of this event
+         */
         void PrintEventName() override {
             PRINTMSG("KeyPressedEvent: {}", m_keycode);
         }
 
+        /**
+         * @brief Predicate for whether the event has
+         *        been fully handled
+         */
         bool Handled() override {
             return this->EventFinised;
         }
 
+        /**
+         * @brief Keycode for the key that has been pressed
+         * 
+         * @return Keycode representing a keyboard key
+         */
         unsigned int GetKeyCode() {
             return m_keycode;
         }
 
+        /**
+         * @brief Type of this event
+         */
         static EventTypes s_GetEventType() {
             return EventTypes::KeyPressed;
         }
@@ -39,27 +68,55 @@ namespace Agate {
         unsigned int m_keycode;
     };
 
+    /**
+     * @brief Emitted when any key is released
+     */
     class KeyReleasedEvent : public Event {
     public:
+
+        /**
+         * @brief Constructor - takes a keycode to identify the
+         *        released key
+         * 
+         * @param keyCode Keycode representing the released key
+         */
         KeyReleasedEvent(int keyCode)
                 : m_keycode(keyCode) {};
 
+        /**
+         * @brief Type of this event
+         */
         EventTypes GetEventType() override {
             return EventTypes::KeyReleased;
         }
 
+        /**
+         * @brief Prints the name of this event
+         */
         void PrintEventName() override {
             PRINTMSG("KeyReleasedEvent: {}", m_keycode);
         }
 
+        /**
+         * @brief Predicate for whether the event has
+         *        been fully handled
+         */
         bool Handled() override {
             return this->EventFinised;
         }
 
+        /**
+         * @brief Keycode for the key that has been released
+         * 
+         * @return Keycode representing a keyboard key
+         */
         unsigned int GetKeyCode() {
             return m_keycode;
         }
 
+        /**
+         * @brief Type of this event
+         */
         static EventTypes s_GetEventType() {
             return EventTypes::KeyReleased;
         }

--- a/Agate/src/Agate/Events/MouseEvent.h
+++ b/Agate/src/Agate/Events/MouseEvent.h
@@ -8,33 +8,66 @@
 #include "Event.h"
 
 namespace Agate {
+
+    /**
+     * @brief Emitted when the mouse cursor moves in the application
+     *        window
+     */
     class MouseMoved : public Event {
     public:
+
+        /**
+         * @brief Constructor - Takes the new cursor coordinates
+         * 
+         * @param x New X coordinate of the cursor
+         * @param y New Y coordinate of the cursor
+         */
         MouseMoved(int x, int y)
                 : m_newXPos(x), m_newYPos(y) {}
 
-
+        /**
+         * @brief Type of this event
+         */
         EventTypes GetEventType() override {
             return EventTypes::MouseMoved;
         }
 
-
+        /**
+         * @brief Prints the name of this event
+         */
         void PrintEventName() override {
             PRINTMSG("MouseMoved to: {}, {}", m_newXPos, m_newYPos);
         }
 
+        /**
+         * @brief New X coordinate of the cursor
+         * 
+         * @return X coordinate of the cursor
+         */
         int GetXPos() {
             return m_newXPos;
         }
 
+        /**
+         * @brief New Y coordinate of the cursor
+         * 
+         * @return Y coordinate of the cursor
+         */
         int GetYPos() {
             return m_newYPos;
         }
 
+        /**
+         * @brief Predicate for whether the event has
+         *        been fully handled
+         */
         bool Handled() override {
             return this->EventFinised;
         }
 
+        /**
+         * @brief Type of this event
+         */
         static EventTypes s_GetEventType() {
             return EventTypes::MouseMoved;
         }
@@ -43,8 +76,16 @@ namespace Agate {
         int m_newXPos, m_newYPos;
     };
 
+    /**
+     * @brief Parent for all mouse button events
+     */
     class MouseButton : public Event {
     protected:
+
+        /**
+         * @brief Constructor - Takes an integer representation
+         *        of the emitting mouse button
+         */
         MouseButton(int button)
                 : m_button(button) {}
 
@@ -53,22 +94,40 @@ namespace Agate {
 
     class API MouseButtonPressed : public MouseButton {
     public:
+
+        /**
+         * @brief Constructor - Takes an integer representation
+         *        of the emitting mouse button
+         */
         MouseButtonPressed(int button)
                 : MouseButton(button) {}
 
+        /**
+         * @brief Type of this event
+         */
         EventTypes GetEventType() override {
             return EventTypes::MouseButtonPressed;
         }
 
+        /**
+         * @brief Prints the name of this event
+         */
         void PrintEventName() override {
             std::string eventString = "MousePressed button: " + std::to_string(m_button);
             PRINTMSG("MousePressed button: {}", m_button);
         }
 
+        /**
+         * @brief Predicate for whether the event has
+         *        been fully handled
+         */
         bool Handled() override {
             return this->EventFinised;
         }
 
+        /**
+         * @brief Type of this event
+         */
         static EventTypes s_GetEventType() {
             return EventTypes::MouseButtonPressed;
         }
@@ -76,21 +135,39 @@ namespace Agate {
 
     class API MouseButtonReleased : public MouseButton {
     public:
+
+        /**
+         * @brief Constructor - Takes an integer representation
+         *        of the emitting mouse button
+         */
         MouseButtonReleased(int button)
                 : MouseButton(button) {}
 
+        /**
+         * @brief Type of this event
+         */
         EventTypes GetEventType() override {
             return EventTypes::MouseButtonReleased;
         }
 
+        /**
+         * @brief Prints the name of this event
+         */
         void PrintEventName() override {
             PRINTMSG("MouseReleased button: {}", m_button);
         }
 
+        /**
+         * @brief Predicate for whether the event has
+         *        been fully handled
+         */
         bool Handled() override {
             return this->EventFinised;
         }
 
+        /**
+         * @brief Type of this event
+         */
         static EventTypes s_GetEventType() {
             return EventTypes::MouseButtonReleased;
         }

--- a/Agate/src/Agate/Events/MouseEvent.h
+++ b/Agate/src/Agate/Events/MouseEvent.h
@@ -1,3 +1,7 @@
+/**
+ * @brief Include file for mouse input events
+ */
+
 #pragma once
 
 #include "Event.h"

--- a/Agate/src/Agate/Events/MouseEvent.h
+++ b/Agate/src/Agate/Events/MouseEvent.h
@@ -2,7 +2,8 @@
  * @brief Include file for mouse input events
  */
 
-#pragma once
+#ifndef AGATE_MOUSEEVENT_H
+#define AGATE_MOUSEEVENT_H
 
 #include "Event.h"
 
@@ -94,4 +95,6 @@ namespace Agate {
             return EventTypes::MouseButtonReleased;
         }
     };
-}// namespace Agate
+} // namespace Agate
+
+#endif // AGATE_MOUSEEVENT_H


### PR DESCRIPTION
This PR adds documentation comments to all header definitions in the Events directory. I'm batching PRs for these issues to prevent overloading one PR with every file's doc comments

Progress on #39 and #40