### PR TITLE
45 model loading on a seperate thread

### DIFF
--- a/Agate/CMakeLists.txt
+++ b/Agate/CMakeLists.txt
@@ -40,10 +40,10 @@ add_subdirectory(${PROJECT_SOURCE_DIR}/vender/glm)
 add_subdirectory(${PROJECT_SOURCE_DIR}/vender/assimp)
 add_subdirectory(${PROJECT_SOURCE_DIR}/vender/SOIL2)
 
-# KTX does not build with C++ 23 and I'm lazy, so we build just it with 17
+# KTX does not build with C++ 20+ and I'm lazy, so we build just it with 17
 set(CMAKE_CXX_STANDARD 17)
 add_subdirectory(${PROJECT_SOURCE_DIR}/vender/KTX)
-set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD 20)
 
 add_compile_definitions(Agate_STATIC GLFW_INCLUDE_NONE)
 

--- a/Agate/CMakeLists.txt
+++ b/Agate/CMakeLists.txt
@@ -3,10 +3,6 @@ cmake_minimum_required(VERSION 3.16)
 #set the project name and version
 project(Agate-lib VERSION 1.0)
 
-#specify the c++ standard
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
-
 # Source files
 file(GLOB_RECURSE libSrc
         ${PROJECT_SOURCE_DIR}/src/*.c
@@ -38,12 +34,16 @@ include_directories("${PROJECT_SOURCE_DIR}/src"
 set(KTX_FEATURE_STATIC_LIBRARY ON CACHE BOOL "Build libktx as a static library" FORCE)
 
 add_subdirectory(${PROJECT_SOURCE_DIR}/vender/glfw)
-add_subdirectory(${PROJECT_SOURCE_DIR}/vender/spdlog)
 add_subdirectory(${PROJECT_SOURCE_DIR}/vender/imgui)
+add_subdirectory(${PROJECT_SOURCE_DIR}/vender/spdlog)
 add_subdirectory(${PROJECT_SOURCE_DIR}/vender/glm)
 add_subdirectory(${PROJECT_SOURCE_DIR}/vender/assimp)
 add_subdirectory(${PROJECT_SOURCE_DIR}/vender/SOIL2)
+
+# KTX does not build with C++ 23 and I'm lazy, so we build just it with 17
+set(CMAKE_CXX_STANDARD 17)
 add_subdirectory(${PROJECT_SOURCE_DIR}/vender/KTX)
+set(CMAKE_CXX_STANDARD 23)
 
 add_compile_definitions(Agate_STATIC GLFW_INCLUDE_NONE)
 

--- a/Agate/src/Agate/Core/Logger.h
+++ b/Agate/src/Agate/Core/Logger.h
@@ -37,7 +37,7 @@ namespace Agate {
         template<typename... Args>
         static void printMSG(const char *file, const char *function, int line, const char *format, Args &&... args) {
             s_Logger->log(spdlog::source_loc{file, line, function}, spdlog::level::info,
-                          fmt::format(format, std::forward<Args>(args)...));
+                          fmt::format(fmt::runtime(format), std::forward<Args>(args)...));
         }
 
         /**
@@ -54,7 +54,7 @@ namespace Agate {
         template<typename... Args>
         static void printWarn(const char *file, const char *function, int line, const char *format, Args &&... args) {
             s_Logger->log(spdlog::source_loc{file, line, function}, spdlog::level::warn,
-                          fmt::format(format, std::forward<Args>(args)...));
+                          fmt::format(fmt::runtime(format), std::forward<Args>(args)...));
         }
 
         /**
@@ -72,7 +72,7 @@ namespace Agate {
         template<typename... Args>
         static void printError(const char *file, const char *function, int line, const char *format, Args &&... args) {
             s_Logger->log(spdlog::source_loc{file, line, function}, spdlog::level::err,
-                          fmt::format(format, std::forward<Args>(args)...));
+                          fmt::format(fmt::runtime(format), std::forward<Args>(args)...));
         }
 
         /**
@@ -88,7 +88,7 @@ namespace Agate {
         template<typename... Args>
         static void printCrit(const char *file, const char *function, int line, const char *format, Args &&... args) {
             s_Logger->log(spdlog::source_loc{file, line, function}, spdlog::level::critical,
-                          fmt::format(format, std::forward<Args>(args)...));
+                          fmt::format(fmt::runtime(format), std::forward<Args>(args)...));
         }
 
     private:

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -129,7 +129,7 @@ void Agate::ModelLoader::Draw(Agate::Shader &shader) {
         auto status = m_futureScene.wait_for(std::chrono::seconds(0));
         if (status == std::future_status::ready) {
             // Once this is done the future scene will no longer be valid
-            prepareScene(m_futureScene.get());
+            prepareScene(std::move(m_futureScene.get()));
         }
     }
 

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -4,6 +4,7 @@
 #include "assimp/scene.h"
 #include "glad/glad.h"
 #include "OpenGl/VertexArray.h"
+#include <sys/types.h>
 #include <thread>
 #include <utility>
 
@@ -110,26 +111,45 @@ void Agate::Mesh::setupMesh() {
 Agate::Mesh::~Mesh() = default;
 
 Agate::ModelLoader::ModelLoader(std::string const &path, bool gamma, bool flipUVs)
-    : m_directory(extractDirectory(path)),m_path(path), gammaCorrection(gamma), m_modelLoaded(false){
-    m_workerThread = std::jthread(&ModelLoader::loadModel, this, flipUVs);
+    : m_directory(extractDirectory(path)),m_path(path), m_gammaCorrection(gamma){
+    // read file via ASSIMP
+    unsigned int assimpFlags = this->getAssimpFlags(flipUVs);
+
+    // This future is used to async load the data of the model file
+    m_futureScene = std::async(std::launch::async, [this, assimpFlags]() {
+                    return m_importer.ReadFile(m_path, assimpFlags);}); 
+
 }
 
 void Agate::ModelLoader::Draw(Agate::Shader &shader) {
-    if (!m_modelLoaded) return;
 
-    // process ASSIMP's root node recursively
-    static bool nodesProccessed = false;
-    if (!nodesProccessed) {  
-        processNode(m_scene->mRootNode, m_scene, glm::mat4(1.0f));
-        nodesProccessed = true;
-        PRINTMSG("model loaded from m_path {}", m_path);
+    // Once we get the scene we prepare it, i.e once we get the futures value we use it 
+    // once used it is no longer valid i.e this if is skipped
+    if (m_futureScene.valid()) {
+        auto status = m_futureScene.wait_for(std::chrono::seconds(0));
+        if (status == std::future_status::ready) {
+            // Once this is done the future scene will no longer be valid
+            prepareScene(m_futureScene.get());
+        }
     }
 
     for (auto &mesh: m_meshes)
         mesh.Draw(shader);
 }
 
-void Agate::ModelLoader::loadModel(bool flipUVs) {
+void Agate::ModelLoader::prepareScene(const aiScene *scene) {
+            // Is the scene valid?
+            if (!scene || scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE || !scene->mRootNode) {
+                PRINTERROR("ASSIMP ERROR: {}", m_importer.GetErrorString());
+                return;
+            }
+
+            // Proccess the nodes once (Note this can be very expensive)
+            processNode(scene->mRootNode, scene, glm::mat4(1.0f));
+            PRINTMSG("Model loaded from path: {}", m_path);
+}
+
+uint Agate::ModelLoader::getAssimpFlags(bool flipUVs) {
     // read file via ASSIMP
     unsigned int assimpFlags = aiProcess_CalcTangentSpace         |
                                aiProcess_Triangulate             |
@@ -139,14 +159,7 @@ void Agate::ModelLoader::loadModel(bool flipUVs) {
     if(flipUVs) {
         assimpFlags |= aiProcess_FlipUVs;
     }
-    m_scene = const_cast<aiScene*>(m_importer.ReadFile(m_path,assimpFlags));//@TODO some models need | aiProcess_FlipUVs
-    // check for errors
-    if (!m_scene || m_scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE || !m_scene->mRootNode) // if is Not Zero
-    {
-        PRINTERROR("ERROR::Model::loadModel Assimp Error: {}", m_importer.GetErrorString());
-        return;
-    }
-    m_modelLoaded = true;
+    return assimpFlags;
 }
 
 void Agate::ModelLoader::processNode(aiNode *node, const aiScene *scene, const glm::mat4 &parentTransform) {
@@ -245,7 +258,7 @@ std::vector<Agate::Texture> Agate::ModelLoader::loadMaterialTextures(aiMaterial 
             }
         }
         if (!skip) {
-            Texture texture(str.C_Str(), this->m_directory, gammaCorrection);
+            Texture texture(str.C_Str(), this->m_directory, m_gammaCorrection);
             texture.setType(typeName);
             textures.push_back(texture);
             textures_loaded.push_back(texture);

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -127,7 +127,7 @@ void Agate::ModelLoader::Draw(Agate::Shader &shader) {
         auto status = m_futureScene.wait_for(std::chrono::seconds(0));
         if (status == std::future_status::ready) {
             // Once this is done the future scene will no longer be valid
-            prepareScene(std::move(m_futureScene.get()));
+            prepareScene(m_futureScene.get());
         }
     }
 
@@ -147,7 +147,7 @@ void Agate::ModelLoader::prepareScene(const aiScene *scene) {
             PRINTMSG("Model loaded from path: {}", m_path);
 }
 
-uint Agate::ModelLoader::getAssimpFlags(bool flipUVs) {
+unsigned int Agate::ModelLoader::getAssimpFlags(bool flipUVs) {
     // read file via ASSIMP
     unsigned int assimpFlags = aiProcess_CalcTangentSpace         |
                                aiProcess_Triangulate             |

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -4,8 +4,6 @@
 #include "assimp/scene.h"
 #include "glad/glad.h"
 #include "OpenGl/VertexArray.h"
-#include <sys/types.h>
-#include <thread>
 #include <utility>
 
 namespace fs = std::filesystem;

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -1,8 +1,10 @@
 #include "agpch.h"
 #include "ModelLoader.h"
 #include "Agate/Core/Logger.h"
+#include "assimp/scene.h"
 #include "glad/glad.h"
 #include "OpenGl/VertexArray.h"
+#include <thread>
 #include <utility>
 
 namespace fs = std::filesystem;
@@ -19,6 +21,7 @@ inline glm::mat4 convertMatrix(const aiMatrix4x4 &matrix) {
                      matrix.a3, matrix.b3, matrix.c3, matrix.d3,
                      matrix.a4, matrix.b4, matrix.c4, matrix.d4);
 }
+
 Agate::Mesh::Mesh(std::vector<Vertex> vertices, std::vector<unsigned int> indices, std::vector<Texture> textures) {
     this->vertices = std::move(vertices);
     this->indices = std::move(indices);
@@ -107,19 +110,27 @@ void Agate::Mesh::setupMesh() {
 Agate::Mesh::~Mesh() = default;
 
 Agate::ModelLoader::ModelLoader(std::string const &path, bool gamma, bool flipUVs)
-    : m_directory(extractDirectory(path)),m_path(path), gammaCorrection(gamma){
-    loadModel(flipUVs);
-    PRINTMSG("model loaded from m_path {}", m_path);
+    : m_directory(extractDirectory(path)),m_path(path), gammaCorrection(gamma), m_modelLoaded(false){
+    m_workerThread = std::jthread(&ModelLoader::loadModel, this, flipUVs);
 }
 
 void Agate::ModelLoader::Draw(Agate::Shader &shader) {
+    if (!m_modelLoaded) return;
+
+    // process ASSIMP's root node recursively
+    static bool nodesProccessed = false;
+    if (!nodesProccessed) {  
+        processNode(m_scene->mRootNode, m_scene, glm::mat4(1.0f));
+        nodesProccessed = true;
+        PRINTMSG("model loaded from m_path {}", m_path);
+    }
+
     for (auto &mesh: m_meshes)
         mesh.Draw(shader);
 }
 
 void Agate::ModelLoader::loadModel(bool flipUVs) {
     // read file via ASSIMP
-    Assimp::Importer importer;
     unsigned int assimpFlags = aiProcess_CalcTangentSpace         |
                                aiProcess_Triangulate             |
                                aiProcess_JoinIdenticalVertices   |
@@ -128,16 +139,14 @@ void Agate::ModelLoader::loadModel(bool flipUVs) {
     if(flipUVs) {
         assimpFlags |= aiProcess_FlipUVs;
     }
-    const aiScene *scene = importer.ReadFile(m_path,assimpFlags);//@TODO some models need | aiProcess_FlipUVs
+    m_scene = const_cast<aiScene*>(m_importer.ReadFile(m_path,assimpFlags));//@TODO some models need | aiProcess_FlipUVs
     // check for errors
-    if (!scene || scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE || !scene->mRootNode) // if is Not Zero
+    if (!m_scene || m_scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE || !m_scene->mRootNode) // if is Not Zero
     {
-        PRINTERROR("ERROR::Model::loadModel Assimp Error: {}", importer.GetErrorString());
+        PRINTERROR("ERROR::Model::loadModel Assimp Error: {}", m_importer.GetErrorString());
         return;
     }
-
-    // process ASSIMP's root node recursively
-    processNode(scene->mRootNode, scene, glm::mat4(1.0f));
+    m_modelLoaded = true;
 }
 
 void Agate::ModelLoader::processNode(aiNode *node, const aiScene *scene, const glm::mat4 &parentTransform) {

--- a/Agate/src/Agate/Rendering/ModelLoader.h
+++ b/Agate/src/Agate/Rendering/ModelLoader.h
@@ -8,6 +8,8 @@
 #include <assimp/Importer.hpp>
 #include <assimp/scene.h>
 #include <assimp/postprocess.h>
+#include <thread>
+#include <atomic>
 
 
 #define MAX_BONE_INFLUENCE 4
@@ -63,6 +65,13 @@ namespace Agate {
         void Draw(Shader &shader);
 
     private:
+        // this thread is used to load the model independent of the main thread
+        std::jthread m_workerThread;
+        std::atomic<bool> m_modelLoaded;
+        aiScene *m_scene;
+        Assimp::Importer m_importer;
+
+
         // loads a model with supported ASSIMP extensions from file and stores the resulting meshes in the meshes vector.
         void loadModel(bool flipUVs = false);
 

--- a/Agate/src/Agate/Rendering/ModelLoader.h
+++ b/Agate/src/Agate/Rendering/ModelLoader.h
@@ -8,10 +8,7 @@
 #include <assimp/Importer.hpp>
 #include <assimp/scene.h>
 #include <assimp/postprocess.h>
-#include <thread>
 #include <future>
-#include <atomic>
-
 
 #define MAX_BONE_INFLUENCE 4
 

--- a/Agate/src/Agate/Rendering/ModelLoader.h
+++ b/Agate/src/Agate/Rendering/ModelLoader.h
@@ -9,6 +9,7 @@
 #include <assimp/scene.h>
 #include <assimp/postprocess.h>
 #include <thread>
+#include <future>
 #include <atomic>
 
 
@@ -56,24 +57,67 @@ namespace Agate {
         std::vector<Mesh> m_meshes;
         std::string m_directory;
         std::string m_path;
-        bool gammaCorrection;
+        bool m_gammaCorrection;
 
-        // constructor, expects a filepath to a 3D model.
+        /**
+         * @brief Construct a ModelLoader and start loading a model on a background task.
+         *
+         * Initializes model metadata and launches an asynchronous Assimp import using
+         * std::async. The returned aiScene* is stored in a std::future so the caller
+         * can continue without blocking.
+         *
+         * @param path     Filesystem path to the model file.
+         * @param gamma    Enable/disable gamma correction for textures.
+         * @param flipUVs  If true, flip UV coordinates vertically during import.
+         *
+         * @note The actual GPU/engine-side preparation is deferred until Draw() observes
+         *       the future is ready and calls prepareScene().
+         */ 
         ModelLoader(std::string const &path, bool gamma = false, bool flipUVs = false);
 
-        // draws the model, and thus all its meshes
+        /**
+        * @brief Render the model; finalize loading when the async import completes.
+        *
+        * Each frame, this function polls the async import future. When the import
+        * completes, it performs one-time scene preparation (node traversal, mesh
+        * extraction, and any associated buffer creation) by calling prepareScene().
+        * After preparation, it draws all loaded meshes.
+        *
+        * @param shader Shader program used to render the meshes.
+        *
+        * @note Non-blocking: if the import is not ready yet, this function only draws
+        *       meshes that have already been prepared (often none).
+        */
         void Draw(Shader &shader);
 
+
     private:
-        // this thread is used to load the model independent of the main thread
-        std::jthread m_workerThread;
-        std::atomic<bool> m_modelLoaded;
-        aiScene *m_scene;
+        // this future is used to load the model independent of the main thread
         Assimp::Importer m_importer;
+        std::future<const aiScene*> m_futureScene;
 
+    private:
+        /**
+        * @brief Build the Assimp post-processing flags for import.
+        *
+        * @param flipUVs If true, include aiProcess_FlipUVs.
+        * @return Bitmask of Assimp aiProcess_* flags passed to ReadFile().
+        */
+        uint getAssimpFlags(bool flipUVs = false);
 
-        // loads a model with supported ASSIMP extensions from file and stores the resulting meshes in the meshes vector.
-        void loadModel(bool flipUVs = false);
+        /**
+        * @brief Convert a loaded Assimp scene into engine-ready mesh data.
+        *
+        * Validates the imported scene and recursively processes the node hierarchy to
+        * populate this loader's mesh list.
+        *
+        * @param scene Scene produced by Assimp::Importer::ReadFile().
+        *
+        * @warning Potentially expensive: performs vertex/index extraction and may
+        *          trigger GPU buffer uploads depending on your Mesh implementation.
+        *          Intended to be called once, after the async import completes.
+        */
+        void prepareScene(const aiScene *scene);
 
         // processes a node in a recursive fashion. Processes each individual mesh located at the node and repeats this process on its children nodes (if any).
         void processNode(aiNode *node, const aiScene *scene, const glm::mat4 &parentTransform);

--- a/Agate/src/Agate/Rendering/ModelLoader.h
+++ b/Agate/src/Agate/Rendering/ModelLoader.h
@@ -100,7 +100,7 @@ namespace Agate {
         * @param flipUVs If true, include aiProcess_FlipUVs.
         * @return Bitmask of Assimp aiProcess_* flags passed to ReadFile().
         */
-        uint getAssimpFlags(bool flipUVs = false);
+        unsigned int getAssimpFlags(bool flipUVs = false);
 
         /**
         * @brief Convert a loaded Assimp scene into engine-ready mesh data.

--- a/Application/CMakeLists.txt
+++ b/Application/CMakeLists.txt
@@ -3,11 +3,6 @@ cmake_minimum_required(VERSION 3.16)
 #set the project name and version
 project(Application VERSION 1.0)
 
-#specify the c++ standard
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
-
-
 file(GLOB appSrc
         "src/*.h"
         "src/*.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.16)
 project(Agate VERSION 1.0)
 
 #specify the c++ standard
-set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # helps IDE's find files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,11 @@ cmake_minimum_required(VERSION 3.16)
 project(Agate VERSION 1.0)
 
 #specify the c++ standard
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# helps IDE's find files
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set(buildDirExecutable ${PROJECT_SOURCE_DIR}/bin/Application/Static)
 


### PR DESCRIPTION
Currently the model loader loads the model from disk on the same thread. This is a major issue as it blocks the main threads and can take seconds. Its not acceptable to block the main event and render thread like this. This PR makes it so when you create the model loader object the model is loaded from disk on a separate thread. You may try to render it before its ready but nothing will happen. Once ready when you call draw it will render.