### PR TITLE
Decouple `ModelLoader` from assimp library (#48)

### DIFF
--- a/Agate/src/Agate.h
+++ b/Agate/src/Agate.h
@@ -24,6 +24,7 @@
 #include <../vender/glm/glm/gtc/type_ptr.hpp>
 
 //-----------Rendering---------
+#include "Agate/Rendering/AssimpLoader.h"
 #include "Agate/Rendering/OpenGl/IndexBuffer.h"
 #include "Agate/Rendering/OpenGl/Render.h"
 #include "Agate/Rendering/OpenGl/VertexArray.h"

--- a/Agate/src/Agate.h
+++ b/Agate/src/Agate.h
@@ -24,7 +24,6 @@
 #include <../vender/glm/glm/gtc/type_ptr.hpp>
 
 //-----------Rendering---------
-#include "Agate/Rendering/AssimpLoader.h"
 #include "Agate/Rendering/OpenGl/IndexBuffer.h"
 #include "Agate/Rendering/OpenGl/Render.h"
 #include "Agate/Rendering/OpenGl/VertexArray.h"

--- a/Agate/src/Agate/Rendering/AssimpLoader.cpp
+++ b/Agate/src/Agate/Rendering/AssimpLoader.cpp
@@ -30,14 +30,6 @@ AssimpLoader::AssimpLoader(std::string path, bool flipUVs):
         ModelLoader(path), flipUVs(flipUVs), scene(nullptr) {}
 
 std::future<bool> AssimpLoader::loadModel() {
-    return readFile();
-}
-
-std::vector<Mesh> AssimpLoader::parseModel() {
-    return std::move(prepareScene());
-}
-
-std::future<bool> AssimpLoader::readFile() {
 
     unsigned int flags = getFlags();
 
@@ -54,7 +46,7 @@ std::future<bool> AssimpLoader::readFile() {
     });
 }
 
-std::vector<Mesh> AssimpLoader::prepareScene() {
+std::vector<Mesh> AssimpLoader::parseModel() {
 
     if (!scene) {
         PRINTERROR("No scene to prepare");

--- a/Agate/src/Agate/Rendering/AssimpLoader.cpp
+++ b/Agate/src/Agate/Rendering/AssimpLoader.cpp
@@ -61,6 +61,19 @@ std::future<const aiScene*> AssimpLoader::readFile(const std::string& path, unsi
     });
 }
 
+std::vector<Mesh> AssimpLoader::prepareScene(const aiScene *scene, std::string path, std::vector<Texture>& textureCache) {
+
+    if (!scene) {
+        PRINTERROR("No scene to prepare");
+        return std::vector<Mesh>();
+    }
+
+    std::vector<Mesh> nodeMeshes = processNode(scene->mRootNode, scene, glm::mat4(1.0f), textureCache);
+    PRINTMSG("Model loaded from path: {}", path);
+
+    return std::move(nodeMeshes);
+}
+
 std::vector<Mesh> Agate::AssimpLoader::processNode(aiNode *node, const aiScene *scene, const glm::mat4 &parentTransform, std::vector<Texture>& textureCache) {
 
     glm::mat4 nodeTransform = parentTransform * convertMatrix(node->mTransformation);

--- a/Agate/src/Agate/Rendering/AssimpLoader.cpp
+++ b/Agate/src/Agate/Rendering/AssimpLoader.cpp
@@ -7,10 +7,28 @@
 #include <future>
 #include <string>
 
+namespace {
+
+/**
+ * Convert an assimp matrix to a glm matrix
+ *
+ * @param matrix The assimp matrix to convert
+ * @return Converted glm matrix
+ */
+inline glm::mat4 convertMatrix(const aiMatrix4x4& matrix) {
+    return glm::mat4(matrix.a1, matrix.b1, matrix.c1, matrix.d1,
+                     matrix.a2, matrix.b2, matrix.c2, matrix.d2,
+                     matrix.a3, matrix.b3, matrix.c3, matrix.d3,
+                     matrix.a4, matrix.b4, matrix.c4, matrix.d4);
+}
+
+} // anonymouse namespace
+
 namespace Agate {
 
 AssimpLoader::AssimpLoader(std::string directory):
     directory(directory) {}
+
 
 unsigned int AssimpLoader::getFlags(bool flipUVs) const {
 
@@ -41,6 +59,25 @@ std::future<const aiScene*> AssimpLoader::readFile(const std::string& path, unsi
 
         return scene;
     });
+}
+
+std::vector<Mesh> Agate::AssimpLoader::processNode(aiNode *node, const aiScene *scene, const glm::mat4 &parentTransform, std::vector<Texture>& textureCache) {
+
+    glm::mat4 nodeTransform = parentTransform * convertMatrix(node->mTransformation);
+    std::vector<Mesh> meshes;
+
+    // Parse meshes in current node
+    for (unsigned int i = 0; i < node->mNumMeshes; i++) {
+        aiMesh *mesh = scene->mMeshes[node->mMeshes[i]];
+        meshes.push_back(processMesh(mesh, scene, nodeTransform, textureCache));
+    }
+
+    // Process child nodes
+    for (unsigned int i = 0; i < node->mNumChildren; i++) {
+        processNode(node->mChildren[i], scene, nodeTransform, textureCache);
+    }
+
+    return std::move(meshes);
 }
 
 Mesh AssimpLoader::processMesh(aiMesh *mesh, const aiScene *scene, const glm::mat4 &transform,

--- a/Agate/src/Agate/Rendering/AssimpLoader.cpp
+++ b/Agate/src/Agate/Rendering/AssimpLoader.cpp
@@ -54,7 +54,7 @@ std::vector<Mesh> AssimpLoader::prepareScene(std::vector<Texture>& textureCache)
     }
 
     std::vector<Mesh> nodeMeshes = processNode(scene->mRootNode, scene, glm::mat4(1.0f), textureCache);
-    PRINTMSG("Model loaded from path: {}", path);
+    PRINTMSG("Model loaded from path \"{}\" with {} meshes", path, nodeMeshes.size());
 
     return std::move(nodeMeshes);
 }
@@ -72,7 +72,8 @@ std::vector<Mesh> Agate::AssimpLoader::processNode(aiNode *node, const aiScene *
 
     // Process child nodes
     for (unsigned int i = 0; i < node->mNumChildren; i++) {
-        processNode(node->mChildren[i], scene, nodeTransform, textureCache);
+        std::vector<Mesh> childMeshes = processNode(node->mChildren[i], scene, nodeTransform, textureCache);
+        meshes.insert(meshes.end(), childMeshes.begin(), childMeshes.end());
     }
 
     return std::move(meshes);

--- a/Agate/src/Agate/Rendering/AssimpLoader.cpp
+++ b/Agate/src/Agate/Rendering/AssimpLoader.cpp
@@ -1,5 +1,6 @@
 #include "AssimpLoader.h"
 #include "Agate/Core/Logger.h"
+#include "Mesh.h"
 #include "OpenGl/Texture.h"
 #include <assimp/postprocess.h>
 #include <assimp/scene.h>
@@ -40,6 +41,75 @@ std::future<const aiScene*> AssimpLoader::readFile(const std::string& path, unsi
 
         return scene;
     });
+}
+
+Mesh AssimpLoader::processMesh(aiMesh *mesh, const aiScene *scene, const glm::mat4 &transform,
+                               std::vector<Texture>& textureCache) {
+    // data to fill
+    std::vector<Vertex> vertices;
+    std::vector<unsigned int> indices;
+    std::vector<Texture> textures;
+
+    // walk through each of the mesh's vertices
+    for (unsigned int i = 0; i < mesh->mNumVertices; i++) {
+        Vertex vertex;
+        glm::vec3 vector;
+        // positions
+        vector.x = mesh->mVertices[i].x;
+        vector.y = mesh->mVertices[i].y;
+        vector.z = mesh->mVertices[i].z;
+        vertex.Position = glm::vec3(transform * glm::vec4(vector, 1.0f));
+        // normals
+        if (mesh->HasNormals()) {
+            vector.x = mesh->mNormals[i].x;
+            vector.y = mesh->mNormals[i].y;
+            vector.z = mesh->mNormals[i].z;
+            vertex.Normal = glm::mat3(transform) * vector;
+        }
+        // texture coordinates
+        if (mesh->mTextureCoords[0]) {
+            glm::vec2 vec;
+            vec.x = mesh->mTextureCoords[0][i].x;
+            vec.y = mesh->mTextureCoords[0][i].y;
+            vertex.TexCoords = vec;
+            // tangent
+            vector.x = mesh->mTangents[i].x;
+            vector.y = mesh->mTangents[i].y;
+            vector.z = mesh->mTangents[i].z;
+            vertex.Tangent = glm::mat3(transform) * vector;
+            // bitangent
+            vector.x = mesh->mBitangents[i].x;
+            vector.y = mesh->mBitangents[i].y;
+            vector.z = mesh->mBitangents[i].z;
+            vertex.Bitangent = glm::mat3(transform) * vector;
+        } else {
+            vertex.TexCoords = glm::vec2(0.0f, 0.0f);
+        }
+
+        vertices.push_back(vertex);
+    }
+    // now walk through each of the mesh's faces (a face is a mesh its triangle) and retrieve the corresponding vertex indices.
+    for (unsigned int i = 0; i < mesh->mNumFaces; i++) {
+        aiFace face = mesh->mFaces[i];
+        for (unsigned int j = 0; j < face.mNumIndices; j++)
+            indices.push_back(face.mIndices[j]);
+    }
+    // process materials
+    aiMaterial *material = scene->mMaterials[mesh->mMaterialIndex];
+
+    std::vector<Texture> diffuseMaps = loadMaterialTextures(material, aiTextureType_DIFFUSE, "texture_diffuse", textureCache);
+    textures.insert(textures.end(), diffuseMaps.begin(), diffuseMaps.end());
+
+    std::vector<Texture> specularMaps = loadMaterialTextures(material, aiTextureType_SPECULAR, "texture_specular", textureCache);
+    textures.insert(textures.end(), specularMaps.begin(), specularMaps.end());
+
+    std::vector<Texture> normalMaps = loadMaterialTextures(material, aiTextureType_HEIGHT, "texture_normal", textureCache);
+    textures.insert(textures.end(), normalMaps.begin(), normalMaps.end());
+
+    std::vector<Texture> heightMaps = loadMaterialTextures(material, aiTextureType_AMBIENT, "texture_height", textureCache);
+    textures.insert(textures.end(), heightMaps.begin(), heightMaps.end());
+
+    return Mesh{vertices, indices, textures};
 }
 
 std::vector<Texture> AssimpLoader::loadMaterialTextures(aiMaterial* material, aiTextureType type, std::string typeName,

--- a/Agate/src/Agate/Rendering/AssimpLoader.cpp
+++ b/Agate/src/Agate/Rendering/AssimpLoader.cpp
@@ -1,6 +1,10 @@
 #include "AssimpLoader.h"
 #include "Agate/Core/Logger.h"
+#include "OpenGl/Texture.h"
 #include <assimp/postprocess.h>
+#include <assimp/scene.h>
+#include <future>
+#include <string>
 
 namespace Agate {
 
@@ -33,6 +37,31 @@ std::future<const aiScene*> AssimpLoader::readFile(const std::string& path, unsi
 
         return scene;
     });
+}
+
+std::vector<Texture> AssimpLoader::loadMaterialTextures(aiMaterial* material, aiTextureType type, std::string typeName,
+                                                        std::string directory, std::vector<Texture>& textureCache) {
+
+    std::vector<Texture> textures;
+    for (unsigned int i = 0; i < material->GetTextureCount(type); i++) {
+        aiString str;
+        material->GetTexture(type, i, &str);
+        bool skip = false;
+        for (auto &j: textureCache) {
+            if (std::strcmp(j.getPath().data(), str.C_Str()) == 0) {
+                textures.push_back(j);
+                skip = true;
+                break;
+            }
+        }
+        if (!skip) {
+            Texture texture(str.C_Str(), directory);
+            texture.setType(typeName);
+            textures.push_back(texture);
+            textureCache.push_back(texture);
+        }
+    }
+    return std::move(textures);
 }
 
 } // namespace Agate

--- a/Agate/src/Agate/Rendering/AssimpLoader.cpp
+++ b/Agate/src/Agate/Rendering/AssimpLoader.cpp
@@ -1,0 +1,5 @@
+#include "AssimpLoader.h"
+#include "assimp/postprocess.h"
+
+namespace Agate {
+} // namespace Agate

--- a/Agate/src/Agate/Rendering/AssimpLoader.cpp
+++ b/Agate/src/Agate/Rendering/AssimpLoader.cpp
@@ -26,27 +26,12 @@ inline glm::mat4 convertMatrix(const aiMatrix4x4& matrix) {
 
 namespace Agate {
 
-AssimpLoader::AssimpLoader(std::string directory, std::string path):
-    directory(directory), path(path) {}
+AssimpLoader::AssimpLoader(std::string directory, std::string path, bool flipUVs):
+    directory(directory), path(path), flipUVs(flipUVs) {}
 
+std::future<const aiScene*> AssimpLoader::readFile() {
 
-unsigned int AssimpLoader::getFlags(bool flipUVs) const {
-
-    // default flags
-    unsigned int assimpFlags = aiProcess_CalcTangentSpace     |
-                            aiProcess_Triangulate             |
-                            aiProcess_JoinIdenticalVertices   |
-                            aiProcess_SortByPType;
-
-    // option flipUVs
-    if(flipUVs) {
-        assimpFlags |= aiProcess_FlipUVs;
-    }
-
-    return assimpFlags;
-}
-
-std::future<const aiScene*> AssimpLoader::readFile(unsigned int flags) {
+    unsigned int flags = getFlags();
 
     return std::async(std::launch::async, [this, flags]() {
 
@@ -185,6 +170,22 @@ std::vector<Texture> AssimpLoader::loadMaterialTextures(aiMaterial* material, ai
         }
     }
     return std::move(textures);
+}
+
+unsigned int AssimpLoader::getFlags() const {
+
+    // default flags
+    unsigned int assimpFlags = aiProcess_CalcTangentSpace     |
+                            aiProcess_Triangulate             |
+                            aiProcess_JoinIdenticalVertices   |
+                            aiProcess_SortByPType;
+
+    // option flipUVs
+    if(flipUVs) {
+        assimpFlags |= aiProcess_FlipUVs;
+    }
+
+    return assimpFlags;
 }
 
 } // namespace Agate

--- a/Agate/src/Agate/Rendering/AssimpLoader.cpp
+++ b/Agate/src/Agate/Rendering/AssimpLoader.cpp
@@ -26,8 +26,16 @@ inline glm::mat4 convertMatrix(const aiMatrix4x4& matrix) {
 
 namespace Agate {
 
-AssimpLoader::AssimpLoader(std::string directory, std::string path, bool flipUVs):
-    directory(directory), path(path), flipUVs(flipUVs), scene(nullptr) {}
+AssimpLoader::AssimpLoader(std::string path, bool flipUVs):
+        ModelLoader(path), flipUVs(flipUVs), scene(nullptr) {}
+
+std::future<bool> AssimpLoader::loadModel() {
+    return readFile();
+}
+
+std::vector<Mesh> AssimpLoader::parseModel() {
+    return std::move(prepareScene());
+}
 
 std::future<bool> AssimpLoader::readFile() {
 
@@ -35,7 +43,7 @@ std::future<bool> AssimpLoader::readFile() {
 
     return std::async(std::launch::async, [this, flags]() {
 
-        this->scene = importer.ReadFile(this->path, flags);
+        this->scene = importer.ReadFile(this->m_path, flags);
 
         if (!scene || scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE || !scene->mRootNode) {
             PRINTERROR("ASSIMP ERROR: {}", importer.GetErrorString());
@@ -46,20 +54,20 @@ std::future<bool> AssimpLoader::readFile() {
     });
 }
 
-std::vector<Mesh> AssimpLoader::prepareScene(std::vector<Texture>& textureCache) {
+std::vector<Mesh> AssimpLoader::prepareScene() {
 
     if (!scene) {
         PRINTERROR("No scene to prepare");
         return std::vector<Mesh>();
     }
 
-    std::vector<Mesh> nodeMeshes = processNode(scene->mRootNode, scene, glm::mat4(1.0f), textureCache);
-    PRINTMSG("Model loaded from path \"{}\" with {} meshes", path, nodeMeshes.size());
+    std::vector<Mesh> nodeMeshes = processNode(scene->mRootNode, scene, glm::mat4(1.0f));
+    PRINTMSG("Model loaded from path \"{}\" with {} meshes", m_path, nodeMeshes.size());
 
     return std::move(nodeMeshes);
 }
 
-std::vector<Mesh> Agate::AssimpLoader::processNode(aiNode *node, const aiScene *scene, const glm::mat4 &parentTransform, std::vector<Texture>& textureCache) {
+std::vector<Mesh> Agate::AssimpLoader::processNode(aiNode *node, const aiScene *scene, const glm::mat4 &parentTransform) {
 
     glm::mat4 nodeTransform = parentTransform * convertMatrix(node->mTransformation);
     std::vector<Mesh> meshes;
@@ -67,20 +75,19 @@ std::vector<Mesh> Agate::AssimpLoader::processNode(aiNode *node, const aiScene *
     // Parse meshes in current node
     for (unsigned int i = 0; i < node->mNumMeshes; i++) {
         aiMesh *mesh = scene->mMeshes[node->mMeshes[i]];
-        meshes.push_back(processMesh(mesh, scene, nodeTransform, textureCache));
+        meshes.push_back(processMesh(mesh, scene, nodeTransform));
     }
 
     // Process child nodes
     for (unsigned int i = 0; i < node->mNumChildren; i++) {
-        std::vector<Mesh> childMeshes = processNode(node->mChildren[i], scene, nodeTransform, textureCache);
+        std::vector<Mesh> childMeshes = processNode(node->mChildren[i], scene, nodeTransform);
         meshes.insert(meshes.end(), childMeshes.begin(), childMeshes.end());
     }
 
     return std::move(meshes);
 }
 
-Mesh AssimpLoader::processMesh(aiMesh *mesh, const aiScene *scene, const glm::mat4 &transform,
-                               std::vector<Texture>& textureCache) {
+Mesh AssimpLoader::processMesh(aiMesh *mesh, const aiScene *scene, const glm::mat4 &transform) {
     // data to fill
     std::vector<Vertex> vertices;
     std::vector<unsigned int> indices;
@@ -133,30 +140,29 @@ Mesh AssimpLoader::processMesh(aiMesh *mesh, const aiScene *scene, const glm::ma
     // process materials
     aiMaterial *material = scene->mMaterials[mesh->mMaterialIndex];
 
-    std::vector<Texture> diffuseMaps = loadMaterialTextures(material, aiTextureType_DIFFUSE, "texture_diffuse", textureCache);
+    std::vector<Texture> diffuseMaps = loadMaterialTextures(material, aiTextureType_DIFFUSE, "texture_diffuse");
     textures.insert(textures.end(), diffuseMaps.begin(), diffuseMaps.end());
 
-    std::vector<Texture> specularMaps = loadMaterialTextures(material, aiTextureType_SPECULAR, "texture_specular", textureCache);
+    std::vector<Texture> specularMaps = loadMaterialTextures(material, aiTextureType_SPECULAR, "texture_specular");
     textures.insert(textures.end(), specularMaps.begin(), specularMaps.end());
 
-    std::vector<Texture> normalMaps = loadMaterialTextures(material, aiTextureType_HEIGHT, "texture_normal", textureCache);
+    std::vector<Texture> normalMaps = loadMaterialTextures(material, aiTextureType_HEIGHT, "texture_normal");
     textures.insert(textures.end(), normalMaps.begin(), normalMaps.end());
 
-    std::vector<Texture> heightMaps = loadMaterialTextures(material, aiTextureType_AMBIENT, "texture_height", textureCache);
+    std::vector<Texture> heightMaps = loadMaterialTextures(material, aiTextureType_AMBIENT, "texture_height");
     textures.insert(textures.end(), heightMaps.begin(), heightMaps.end());
 
     return Mesh{vertices, indices, textures};
 }
 
-std::vector<Texture> AssimpLoader::loadMaterialTextures(aiMaterial* material, aiTextureType type, std::string typeName,
-                                                        std::vector<Texture>& textureCache) {
+std::vector<Texture> AssimpLoader::loadMaterialTextures(aiMaterial* material, aiTextureType type, std::string typeName) {
 
     std::vector<Texture> textures;
     for (unsigned int i = 0; i < material->GetTextureCount(type); i++) {
         aiString str;
         material->GetTexture(type, i, &str);
         bool skip = false;
-        for (auto &j: textureCache) {
+        for (auto &j: textures_loaded) {
             if (std::strcmp(j.getPath().data(), str.C_Str()) == 0) {
                 textures.push_back(j);
                 skip = true;
@@ -164,10 +170,10 @@ std::vector<Texture> AssimpLoader::loadMaterialTextures(aiMaterial* material, ai
             }
         }
         if (!skip) {
-            Texture texture(str.C_Str(), directory);
+            Texture texture(str.C_Str(), m_directory);
             texture.setType(typeName);
             textures.push_back(texture);
-            textureCache.push_back(texture);
+            textures_loaded.push_back(texture);
         }
     }
     return std::move(textures);

--- a/Agate/src/Agate/Rendering/AssimpLoader.cpp
+++ b/Agate/src/Agate/Rendering/AssimpLoader.cpp
@@ -8,6 +8,9 @@
 
 namespace Agate {
 
+AssimpLoader::AssimpLoader(std::string directory):
+    directory(directory) {}
+
 unsigned int AssimpLoader::getFlags(bool flipUVs) const {
 
     // default flags
@@ -40,7 +43,7 @@ std::future<const aiScene*> AssimpLoader::readFile(const std::string& path, unsi
 }
 
 std::vector<Texture> AssimpLoader::loadMaterialTextures(aiMaterial* material, aiTextureType type, std::string typeName,
-                                                        std::string directory, std::vector<Texture>& textureCache) {
+                                                        std::vector<Texture>& textureCache) {
 
     std::vector<Texture> textures;
     for (unsigned int i = 0; i < material->GetTextureCount(type); i++) {

--- a/Agate/src/Agate/Rendering/AssimpLoader.cpp
+++ b/Agate/src/Agate/Rendering/AssimpLoader.cpp
@@ -56,7 +56,7 @@ std::vector<Mesh> AssimpLoader::parseModel() {
     std::vector<Mesh> nodeMeshes = processNode(m_scene->mRootNode, m_scene, glm::mat4(1.0f));
     PRINTMSG("Model loaded from path \"{}\" with {} meshes", m_path, nodeMeshes.size());
 
-    return std::move(nodeMeshes);
+    return nodeMeshes;
 }
 
 std::vector<Mesh> Agate::AssimpLoader::processNode(aiNode *node, const aiScene *scene, const glm::mat4 &parentTransform) {
@@ -76,7 +76,7 @@ std::vector<Mesh> Agate::AssimpLoader::processNode(aiNode *node, const aiScene *
         meshes.insert(meshes.end(), childMeshes.begin(), childMeshes.end());
     }
 
-    return std::move(meshes);
+    return meshes;
 }
 
 Mesh AssimpLoader::processMesh(aiMesh *mesh, const aiScene *scene, const glm::mat4 &transform) {
@@ -168,7 +168,7 @@ std::vector<Texture> AssimpLoader::loadMaterialTextures(aiMaterial* material, ai
             m_texturesLoaded.push_back(texture);
         }
     }
-    return std::move(textures);
+    return textures;
 }
 
 unsigned int AssimpLoader::getFlags() const {

--- a/Agate/src/Agate/Rendering/AssimpLoader.cpp
+++ b/Agate/src/Agate/Rendering/AssimpLoader.cpp
@@ -1,5 +1,6 @@
 #include "AssimpLoader.h"
-#include "assimp/postprocess.h"
+#include "Agate/Core/Logger.h"
+#include <assimp/postprocess.h>
 
 namespace Agate {
 
@@ -17,6 +18,21 @@ unsigned int AssimpLoader::getFlags(bool flipUVs) const {
     }
 
     return assimpFlags;
+}
+
+std::future<const aiScene*> AssimpLoader::readFile(const std::string& path, unsigned int flags) {
+
+    return std::async(std::launch::async, [this, path, flags]() {
+
+        const aiScene* scene = importer.ReadFile(path, flags);
+
+        if (!scene || scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE || !scene->mRootNode) {
+            PRINTERROR("ASSIMP ERROR: {}", importer.GetErrorString());
+            return static_cast<const aiScene*>(nullptr);
+        }
+
+        return scene;
+    });
 }
 
 } // namespace Agate

--- a/Agate/src/Agate/Rendering/AssimpLoader.cpp
+++ b/Agate/src/Agate/Rendering/AssimpLoader.cpp
@@ -2,4 +2,21 @@
 #include "assimp/postprocess.h"
 
 namespace Agate {
+
+unsigned int AssimpLoader::getFlags(bool flipUVs) const {
+
+    // default flags
+    unsigned int assimpFlags = aiProcess_CalcTangentSpace     |
+                            aiProcess_Triangulate             |
+                            aiProcess_JoinIdenticalVertices   |
+                            aiProcess_SortByPType;
+
+    // option flipUVs
+    if(flipUVs) {
+        assimpFlags |= aiProcess_FlipUVs;
+    }
+
+    return assimpFlags;
+}
+
 } // namespace Agate

--- a/Agate/src/Agate/Rendering/AssimpLoader.cpp
+++ b/Agate/src/Agate/Rendering/AssimpLoader.cpp
@@ -27,26 +27,26 @@ inline glm::mat4 convertMatrix(const aiMatrix4x4& matrix) {
 namespace Agate {
 
 AssimpLoader::AssimpLoader(std::string directory, std::string path, bool flipUVs):
-    directory(directory), path(path), flipUVs(flipUVs) {}
+    directory(directory), path(path), flipUVs(flipUVs), scene(nullptr) {}
 
-std::future<const aiScene*> AssimpLoader::readFile() {
+std::future<bool> AssimpLoader::readFile() {
 
     unsigned int flags = getFlags();
 
     return std::async(std::launch::async, [this, flags]() {
 
-        const aiScene* scene = importer.ReadFile(this->path, flags);
+        this->scene = importer.ReadFile(this->path, flags);
 
         if (!scene || scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE || !scene->mRootNode) {
             PRINTERROR("ASSIMP ERROR: {}", importer.GetErrorString());
-            return static_cast<const aiScene*>(nullptr);
+            return false;
         }
 
-        return scene;
+        return true;
     });
 }
 
-std::vector<Mesh> AssimpLoader::prepareScene(const aiScene *scene, std::vector<Texture>& textureCache) {
+std::vector<Mesh> AssimpLoader::prepareScene(std::vector<Texture>& textureCache) {
 
     if (!scene) {
         PRINTERROR("No scene to prepare");

--- a/Agate/src/Agate/Rendering/AssimpLoader.cpp
+++ b/Agate/src/Agate/Rendering/AssimpLoader.cpp
@@ -27,7 +27,7 @@ inline glm::mat4 convertMatrix(const aiMatrix4x4& matrix) {
 namespace Agate {
 
 AssimpLoader::AssimpLoader(std::string path, bool flipUVs):
-        ModelLoader(path), flipUVs(flipUVs), scene(nullptr) {}
+        ModelLoader(path), m_flipUVs(flipUVs), m_scene(nullptr) {}
 
 std::future<bool> AssimpLoader::loadModel() {
 
@@ -35,10 +35,10 @@ std::future<bool> AssimpLoader::loadModel() {
 
     return std::async(std::launch::async, [this, flags]() {
 
-        this->scene = importer.ReadFile(this->m_path, flags);
+        this->m_scene = m_importer.ReadFile(this->m_path, flags);
 
-        if (!scene || scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE || !scene->mRootNode) {
-            PRINTERROR("ASSIMP ERROR: {}", importer.GetErrorString());
+        if (!m_scene || m_scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE || !m_scene->mRootNode) {
+            PRINTERROR("ASSIMP ERROR: {}", m_importer.GetErrorString());
             return false;
         }
 
@@ -48,12 +48,12 @@ std::future<bool> AssimpLoader::loadModel() {
 
 std::vector<Mesh> AssimpLoader::parseModel() {
 
-    if (!scene) {
+    if (!m_scene) {
         PRINTERROR("No scene to prepare");
         return std::vector<Mesh>();
     }
 
-    std::vector<Mesh> nodeMeshes = processNode(scene->mRootNode, scene, glm::mat4(1.0f));
+    std::vector<Mesh> nodeMeshes = processNode(m_scene->mRootNode, m_scene, glm::mat4(1.0f));
     PRINTMSG("Model loaded from path \"{}\" with {} meshes", m_path, nodeMeshes.size());
 
     return std::move(nodeMeshes);
@@ -154,7 +154,7 @@ std::vector<Texture> AssimpLoader::loadMaterialTextures(aiMaterial* material, ai
         aiString str;
         material->GetTexture(type, i, &str);
         bool skip = false;
-        for (auto &j: textures_loaded) {
+        for (auto &j: m_texturesLoaded) {
             if (std::strcmp(j.getPath().data(), str.C_Str()) == 0) {
                 textures.push_back(j);
                 skip = true;
@@ -165,7 +165,7 @@ std::vector<Texture> AssimpLoader::loadMaterialTextures(aiMaterial* material, ai
             Texture texture(str.C_Str(), m_directory);
             texture.setType(typeName);
             textures.push_back(texture);
-            textures_loaded.push_back(texture);
+            m_texturesLoaded.push_back(texture);
         }
     }
     return std::move(textures);
@@ -180,7 +180,7 @@ unsigned int AssimpLoader::getFlags() const {
                             aiProcess_SortByPType;
 
     // option flipUVs
-    if(flipUVs) {
+    if(m_flipUVs) {
         assimpFlags |= aiProcess_FlipUVs;
     }
 

--- a/Agate/src/Agate/Rendering/AssimpLoader.cpp
+++ b/Agate/src/Agate/Rendering/AssimpLoader.cpp
@@ -26,8 +26,8 @@ inline glm::mat4 convertMatrix(const aiMatrix4x4& matrix) {
 
 namespace Agate {
 
-AssimpLoader::AssimpLoader(std::string directory):
-    directory(directory) {}
+AssimpLoader::AssimpLoader(std::string directory, std::string path):
+    directory(directory), path(path) {}
 
 
 unsigned int AssimpLoader::getFlags(bool flipUVs) const {
@@ -46,11 +46,11 @@ unsigned int AssimpLoader::getFlags(bool flipUVs) const {
     return assimpFlags;
 }
 
-std::future<const aiScene*> AssimpLoader::readFile(const std::string& path, unsigned int flags) {
+std::future<const aiScene*> AssimpLoader::readFile(unsigned int flags) {
 
-    return std::async(std::launch::async, [this, path, flags]() {
+    return std::async(std::launch::async, [this, flags]() {
 
-        const aiScene* scene = importer.ReadFile(path, flags);
+        const aiScene* scene = importer.ReadFile(this->path, flags);
 
         if (!scene || scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE || !scene->mRootNode) {
             PRINTERROR("ASSIMP ERROR: {}", importer.GetErrorString());
@@ -61,7 +61,7 @@ std::future<const aiScene*> AssimpLoader::readFile(const std::string& path, unsi
     });
 }
 
-std::vector<Mesh> AssimpLoader::prepareScene(const aiScene *scene, std::string path, std::vector<Texture>& textureCache) {
+std::vector<Mesh> AssimpLoader::prepareScene(const aiScene *scene, std::vector<Texture>& textureCache) {
 
     if (!scene) {
         PRINTERROR("No scene to prepare");

--- a/Agate/src/Agate/Rendering/AssimpLoader.cpp
+++ b/Agate/src/Agate/Rendering/AssimpLoader.cpp
@@ -22,7 +22,7 @@ inline glm::mat4 convertMatrix(const aiMatrix4x4& matrix) {
                      matrix.a4, matrix.b4, matrix.c4, matrix.d4);
 }
 
-} // anonymouse namespace
+} // anonymous namespace
 
 namespace Agate {
 

--- a/Agate/src/Agate/Rendering/AssimpLoader.h
+++ b/Agate/src/Agate/Rendering/AssimpLoader.h
@@ -51,6 +51,22 @@ public:
     std::future<const aiScene*> readFile(const std::string& path, unsigned int flags);
 
     /**
+    * @brief Convert a loaded Assimp scene into engine-ready mesh data.
+    *
+    * Validates the imported scene and recursively processes the node hierarchy to
+    * populate this loader's mesh list.
+    *
+    * @param scene Scene produced by Assimp::Importer::ReadFile()
+    * @param path
+    * @param textureCache
+    *
+    * @warning Potentially expensive: performs vertex/index extraction and may
+    *          trigger GPU buffer uploads depending on your Mesh implementation.
+    *          Intended to be called once, after the async import completes.
+    */
+    std::vector<Mesh> prepareScene(const aiScene *scene, std::string path, std::vector<Texture>& textureCache);
+
+    /**
      * @brief Recursively processes a node and its children, parsing out
      *        all contained meshes
      * 

--- a/Agate/src/Agate/Rendering/AssimpLoader.h
+++ b/Agate/src/Agate/Rendering/AssimpLoader.h
@@ -30,8 +30,9 @@ public:
      * @brief Constructor
      * 
      * @param directory Directory where the model is located
+     * @param path Path to the model file
      */
-    AssimpLoader(std::string directory);
+    AssimpLoader(std::string directory, std::string path);
 
     /**
      * @brief Builds flags for import post-processing options
@@ -44,11 +45,10 @@ public:
     /**
      * @brief Imports a model from a file as an assimp scene
      * 
-     * @param path Path to the model file
      * @param flags Post-processing flags for Assimp::Importer::ReadFile
      * @return Assimp scene with model data
      */
-    std::future<const aiScene*> readFile(const std::string& path, unsigned int flags);
+    std::future<const aiScene*> readFile(unsigned int flags);
 
     /**
     * @brief Convert a loaded Assimp scene into engine-ready mesh data.
@@ -57,14 +57,13 @@ public:
     * populate this loader's mesh list.
     *
     * @param scene Scene produced by Assimp::Importer::ReadFile()
-    * @param path
     * @param textureCache
     *
     * @warning Potentially expensive: performs vertex/index extraction and may
     *          trigger GPU buffer uploads depending on your Mesh implementation.
     *          Intended to be called once, after the async import completes.
     */
-    std::vector<Mesh> prepareScene(const aiScene *scene, std::string path, std::vector<Texture>& textureCache);
+    std::vector<Mesh> prepareScene(const aiScene *scene, std::vector<Texture>& textureCache);
 
     /**
      * @brief Recursively processes a node and its children, parsing out
@@ -107,6 +106,7 @@ public:
 private:
     Assimp::Importer importer;
     std::string directory;
+    std::string path;
 };
 
 } // namespace Agate

--- a/Agate/src/Agate/Rendering/AssimpLoader.h
+++ b/Agate/src/Agate/Rendering/AssimpLoader.h
@@ -9,14 +9,13 @@
 #ifndef AGATE_ASSIMPLOADER_H
 #define AGATE_ASSIMPLOADER_H
 
+#include "OpenGl/Texture.h"
 #include <future>
 #include <string>
 #include <assimp/Importer.hpp>
 #include <assimp/scene.h>
 
 namespace Agate {
-
-struct AssimpLoaderImpl;
 
 /**
  * @brief Wraps calls to assimp and decouples assimp implementation
@@ -46,6 +45,19 @@ public:
      * @return Assimp scene with model data
      */
     std::future<const aiScene*> readFile(const std::string& path, unsigned int flags);
+
+    /**
+     * @brief Loads textures required for this material
+     * 
+     * @param material Material to load textures for
+     * @param type Type of textures to load
+     * @param typeName Name for the type of textures to load
+     * @param directory Directory of source model file
+     * @param textureCache Cache of previously loaded textures
+     * 
+     * @return Textures required by this material
+     */
+    std::vector<Texture> loadMaterialTextures(aiMaterial* material, aiTextureType type, std::string typeName, std::string directory, std::vector<Texture>& textureCache);
 
 private:
     Assimp::Importer importer;

--- a/Agate/src/Agate/Rendering/AssimpLoader.h
+++ b/Agate/src/Agate/Rendering/AssimpLoader.h
@@ -39,9 +39,11 @@ public:
     /**
      * @brief Imports a model from a file as an assimp scene
      * 
-     * @return Assimp scene with model data
+     * @return Status
+     * @retval true Success
+     * @retval false Error
      */
-    std::future<const aiScene*> readFile();
+    std::future<bool> readFile();
 
     /**
     * @brief Convert a loaded Assimp scene into engine-ready mesh data.
@@ -49,20 +51,20 @@ public:
     * Validates the imported scene and recursively processes the node hierarchy to
     * populate this loader's mesh list.
     *
-    * @param scene Scene produced by Assimp::Importer::ReadFile()
     * @param textureCache
     *
     * @warning Potentially expensive: performs vertex/index extraction and may
     *          trigger GPU buffer uploads depending on your Mesh implementation.
     *          Intended to be called once, after the async import completes.
     */
-    std::vector<Mesh> prepareScene(const aiScene *scene, std::vector<Texture>& textureCache);
+    std::vector<Mesh> prepareScene(std::vector<Texture>& textureCache);
 
 private:
     Assimp::Importer importer;
     std::string directory;
     std::string path;
     bool flipUVs;
+    const aiScene* scene;
 
     /**
      * @brief Recursively processes a node and its children, parsing out

--- a/Agate/src/Agate/Rendering/AssimpLoader.h
+++ b/Agate/src/Agate/Rendering/AssimpLoader.h
@@ -10,6 +10,7 @@
 #define AGATE_ASSIMPLOADER_H
 
 #include "Mesh.h"
+#include "ModelLoader.h"
 #include "OpenGl/Texture.h"
 #include <future>
 #include <string>
@@ -23,18 +24,44 @@ namespace Agate {
  * @brief Wraps calls to assimp and decouples assimp implementation
  *        details from the engine
  */
-class AssimpLoader {
+class AssimpLoader : public ModelLoader {
 public:
 
     /**
      * @brief Constructor
      * 
-     * @param directory Directory where the model is located
      * @param path Path to the model file
      * @param flipUVs If true, include aiProcess_FlipUVs for postprocessing.
      *                Default false
      */
-    AssimpLoader(std::string directory, std::string path, bool flipUVs = false);
+    AssimpLoader(std::string path, bool flipUVs = false);
+
+protected:
+
+    /**
+     * @brief Starts loading the model this loader was given
+     * 
+     * @return Future that becomes valid upon completion of loading the model
+     *         and indicates operation status
+     * @retval true Success
+     * @retval false Error
+     * 
+     * @note Implementations are encouraged to define this in a non-blocking
+     *       manner
+     */
+    virtual std::future<bool> loadModel() final override;
+
+    /**
+     * @brief Parses the loaded model into a form that the engine can render
+     * 
+     * @return Parsed meshes
+     */
+    virtual std::vector<Mesh> parseModel() final override;
+
+private:
+    Assimp::Importer importer;
+    bool flipUVs;
+    const aiScene* scene;
 
     /**
      * @brief Imports a model from a file as an assimp scene
@@ -51,20 +78,11 @@ public:
     * Validates the imported scene and recursively processes the node hierarchy to
     * populate this loader's mesh list.
     *
-    * @param textureCache
-    *
     * @warning Potentially expensive: performs vertex/index extraction and may
     *          trigger GPU buffer uploads depending on your Mesh implementation.
     *          Intended to be called once, after the async import completes.
     */
-    std::vector<Mesh> prepareScene(std::vector<Texture>& textureCache);
-
-private:
-    Assimp::Importer importer;
-    std::string directory;
-    std::string path;
-    bool flipUVs;
-    const aiScene* scene;
+    std::vector<Mesh> prepareScene();
 
     /**
      * @brief Recursively processes a node and its children, parsing out
@@ -74,11 +92,10 @@ private:
      * @param scene Scene containing the node
      * @param transform Transformation matrix of the current node relative to
      *                  the scene origin
-     * @param textureCache Cache of previously loaded textures
      * 
      * @return Parsed meshes
      */
-    std::vector<Mesh> processNode(aiNode *node, const aiScene *scene, const glm::mat4 &parentTransform, std::vector<Texture>& textureCache);
+    std::vector<Mesh> processNode(aiNode *node, const aiScene *scene, const glm::mat4 &parentTransform);
 
     /**
      * @brief Parses a Mesh out of an assimp scene
@@ -86,11 +103,10 @@ private:
      * @param mesh Assimp representation of the mesh
      * @param scene Assimp scene containing the mesh
      * @param transform Local transformation of the mesh within the scene
-     * @param textureCache Cache of previously loaded textures
      * 
      * @return Parsed mesh
      */
-    Mesh processMesh(aiMesh *mesh, const aiScene *scene, const glm::mat4 &transform, std::vector<Texture>& textureCache);
+    Mesh processMesh(aiMesh *mesh, const aiScene *scene, const glm::mat4 &transform);
 
     /**
      * @brief Loads textures required for this material
@@ -98,11 +114,10 @@ private:
      * @param material Material to load textures for
      * @param type Type of textures to load
      * @param typeName Name for the type of textures to load
-     * @param textureCache Cache of previously loaded textures
      * 
      * @return Textures required by this material
      */
-    std::vector<Texture> loadMaterialTextures(aiMaterial* material, aiTextureType type, std::string typeName, std::vector<Texture>& textureCache);
+    std::vector<Texture> loadMaterialTextures(aiMaterial* material, aiTextureType type, std::string typeName);
 
     /**
      * @brief Builds flags for import post-processing options

--- a/Agate/src/Agate/Rendering/AssimpLoader.h
+++ b/Agate/src/Agate/Rendering/AssimpLoader.h
@@ -22,6 +22,14 @@ public:
      * @brief Default constructor
      */
     AssimpLoader() = default;
+
+    /**
+     * @brief Builds flags for import post-processing options
+     * 
+     * @param flipUVs If true, include aiProcess_FlipUVs. Default false
+     * @return Bitmask representing the post-processing flags
+     */
+    unsigned int getFlags(bool flipUVs = false) const;
 };
 
 } // namespace Agate

--- a/Agate/src/Agate/Rendering/AssimpLoader.h
+++ b/Agate/src/Agate/Rendering/AssimpLoader.h
@@ -59,9 +59,9 @@ protected:
     virtual std::vector<Mesh> parseModel() final override;
 
 private:
-    Assimp::Importer importer;
-    bool flipUVs;
-    const aiScene* scene;
+    Assimp::Importer m_importer;
+    bool m_flipUVs;
+    const aiScene* m_scene;
 
     /**
      * @brief Recursively processes a node and its children, parsing out

--- a/Agate/src/Agate/Rendering/AssimpLoader.h
+++ b/Agate/src/Agate/Rendering/AssimpLoader.h
@@ -1,0 +1,29 @@
+/**
+ * @brief Include file for the AssimpLoader class
+ * 
+ * Hides assimp's implementation details from the rest of the
+ * engine in order to protect against unintended usage of the
+ * library
+ */
+
+#ifndef AGATE_ASSIMPLOADER_H
+#define AGATE_ASSIMPLOADER_H
+
+namespace Agate {
+
+/**
+ * @brief Wraps calls to assimp and decouples assimp implementation
+ *        details from the engine
+ */
+class AssimpLoader {
+public:
+
+    /**
+     * @brief Default constructor
+     */
+    AssimpLoader() = default;
+};
+
+} // namespace Agate
+
+#endif // AGATE_ASSIMPLOADER_H

--- a/Agate/src/Agate/Rendering/AssimpLoader.h
+++ b/Agate/src/Agate/Rendering/AssimpLoader.h
@@ -51,12 +51,28 @@ public:
     std::future<const aiScene*> readFile(const std::string& path, unsigned int flags);
 
     /**
+     * @brief Recursively processes a node and its children, parsing out
+     *        all contained meshes
+     * 
+     * @param node Current node to process
+     * @param scene Scene containing the node
+     * @param transform Transformation matrix of the current node relative to
+     *                  the scene origin
+     * @param textureCache Cache of previously loaded textures
+     * 
+     * @return Parsed meshes
+     */
+    std::vector<Mesh> processNode(aiNode *node, const aiScene *scene, const glm::mat4 &parentTransform, std::vector<Texture>& textureCache);
+
+    /**
      * @brief Parses a Mesh out of an assimp scene
      * 
      * @param mesh Assimp representation of the mesh
      * @param scene Assimp scene containing the mesh
      * @param transform Local transformation of the mesh within the scene
      * @param textureCache Cache of previously loaded textures
+     * 
+     * @return Parsed mesh
      */
     Mesh processMesh(aiMesh *mesh, const aiScene *scene, const glm::mat4 &transform, std::vector<Texture>& textureCache);
 

--- a/Agate/src/Agate/Rendering/AssimpLoader.h
+++ b/Agate/src/Agate/Rendering/AssimpLoader.h
@@ -31,24 +31,17 @@ public:
      * 
      * @param directory Directory where the model is located
      * @param path Path to the model file
+     * @param flipUVs If true, include aiProcess_FlipUVs for postprocessing.
+     *                Default false
      */
-    AssimpLoader(std::string directory, std::string path);
-
-    /**
-     * @brief Builds flags for import post-processing options
-     * 
-     * @param flipUVs If true, include aiProcess_FlipUVs. Default false
-     * @return Bitmask representing the post-processing flags
-     */
-    unsigned int getFlags(bool flipUVs = false) const;
+    AssimpLoader(std::string directory, std::string path, bool flipUVs = false);
 
     /**
      * @brief Imports a model from a file as an assimp scene
      * 
-     * @param flags Post-processing flags for Assimp::Importer::ReadFile
      * @return Assimp scene with model data
      */
-    std::future<const aiScene*> readFile(unsigned int flags);
+    std::future<const aiScene*> readFile();
 
     /**
     * @brief Convert a loaded Assimp scene into engine-ready mesh data.
@@ -64,6 +57,14 @@ public:
     *          Intended to be called once, after the async import completes.
     */
     std::vector<Mesh> prepareScene(const aiScene *scene, std::vector<Texture>& textureCache);
+
+
+
+private:
+    Assimp::Importer importer;
+    std::string directory;
+    std::string path;
+    bool flipUVs;
 
     /**
      * @brief Recursively processes a node and its children, parsing out
@@ -103,10 +104,12 @@ public:
      */
     std::vector<Texture> loadMaterialTextures(aiMaterial* material, aiTextureType type, std::string typeName, std::vector<Texture>& textureCache);
 
-private:
-    Assimp::Importer importer;
-    std::string directory;
-    std::string path;
+    /**
+     * @brief Builds flags for import post-processing options
+     * 
+     * @return Bitmask representing the post-processing flags
+     */
+    unsigned int getFlags() const;
 };
 
 } // namespace Agate

--- a/Agate/src/Agate/Rendering/AssimpLoader.h
+++ b/Agate/src/Agate/Rendering/AssimpLoader.h
@@ -9,7 +9,14 @@
 #ifndef AGATE_ASSIMPLOADER_H
 #define AGATE_ASSIMPLOADER_H
 
+#include <future>
+#include <string>
+#include <assimp/Importer.hpp>
+#include <assimp/scene.h>
+
 namespace Agate {
+
+struct AssimpLoaderImpl;
 
 /**
  * @brief Wraps calls to assimp and decouples assimp implementation
@@ -30,6 +37,18 @@ public:
      * @return Bitmask representing the post-processing flags
      */
     unsigned int getFlags(bool flipUVs = false) const;
+
+    /**
+     * @brief Imports a model from a file as an assimp scene
+     * 
+     * @param path Path to the model file
+     * @param flags Post-processing flags for Assimp::Importer::ReadFile
+     * @return Assimp scene with model data
+     */
+    std::future<const aiScene*> readFile(const std::string& path, unsigned int flags);
+
+private:
+    Assimp::Importer importer;
 };
 
 } // namespace Agate

--- a/Agate/src/Agate/Rendering/AssimpLoader.h
+++ b/Agate/src/Agate/Rendering/AssimpLoader.h
@@ -58,8 +58,6 @@ public:
     */
     std::vector<Mesh> prepareScene(const aiScene *scene, std::vector<Texture>& textureCache);
 
-
-
 private:
     Assimp::Importer importer;
     std::string directory;

--- a/Agate/src/Agate/Rendering/AssimpLoader.h
+++ b/Agate/src/Agate/Rendering/AssimpLoader.h
@@ -9,11 +9,13 @@
 #ifndef AGATE_ASSIMPLOADER_H
 #define AGATE_ASSIMPLOADER_H
 
+#include "Mesh.h"
 #include "OpenGl/Texture.h"
 #include <future>
 #include <string>
 #include <assimp/Importer.hpp>
 #include <assimp/scene.h>
+#include <glm/glm.hpp>
 
 namespace Agate {
 
@@ -47,6 +49,16 @@ public:
      * @return Assimp scene with model data
      */
     std::future<const aiScene*> readFile(const std::string& path, unsigned int flags);
+
+    /**
+     * @brief Parses a Mesh out of an assimp scene
+     * 
+     * @param mesh Assimp representation of the mesh
+     * @param scene Assimp scene containing the mesh
+     * @param transform Local transformation of the mesh within the scene
+     * @param textureCache Cache of previously loaded textures
+     */
+    Mesh processMesh(aiMesh *mesh, const aiScene *scene, const glm::mat4 &transform, std::vector<Texture>& textureCache);
 
     /**
      * @brief Loads textures required for this material

--- a/Agate/src/Agate/Rendering/AssimpLoader.h
+++ b/Agate/src/Agate/Rendering/AssimpLoader.h
@@ -25,9 +25,11 @@ class AssimpLoader {
 public:
 
     /**
-     * @brief Default constructor
+     * @brief Constructor
+     * 
+     * @param directory Directory where the model is located
      */
-    AssimpLoader() = default;
+    AssimpLoader(std::string directory);
 
     /**
      * @brief Builds flags for import post-processing options
@@ -52,15 +54,15 @@ public:
      * @param material Material to load textures for
      * @param type Type of textures to load
      * @param typeName Name for the type of textures to load
-     * @param directory Directory of source model file
      * @param textureCache Cache of previously loaded textures
      * 
      * @return Textures required by this material
      */
-    std::vector<Texture> loadMaterialTextures(aiMaterial* material, aiTextureType type, std::string typeName, std::string directory, std::vector<Texture>& textureCache);
+    std::vector<Texture> loadMaterialTextures(aiMaterial* material, aiTextureType type, std::string typeName, std::vector<Texture>& textureCache);
 
 private:
     Assimp::Importer importer;
+    std::string directory;
 };
 
 } // namespace Agate

--- a/Agate/src/Agate/Rendering/AssimpLoader.h
+++ b/Agate/src/Agate/Rendering/AssimpLoader.h
@@ -64,27 +64,6 @@ private:
     const aiScene* scene;
 
     /**
-     * @brief Imports a model from a file as an assimp scene
-     * 
-     * @return Status
-     * @retval true Success
-     * @retval false Error
-     */
-    std::future<bool> readFile();
-
-    /**
-    * @brief Convert a loaded Assimp scene into engine-ready mesh data.
-    *
-    * Validates the imported scene and recursively processes the node hierarchy to
-    * populate this loader's mesh list.
-    *
-    * @warning Potentially expensive: performs vertex/index extraction and may
-    *          trigger GPU buffer uploads depending on your Mesh implementation.
-    *          Intended to be called once, after the async import completes.
-    */
-    std::vector<Mesh> prepareScene();
-
-    /**
      * @brief Recursively processes a node and its children, parsing out
      *        all contained meshes
      * 

--- a/Agate/src/Agate/Rendering/Mesh.cpp
+++ b/Agate/src/Agate/Rendering/Mesh.cpp
@@ -75,6 +75,10 @@ void Mesh::Draw(Agate::Shader &shader) {
 
 void Mesh::setupMesh() {
 
+    if (m_vertices.empty()) {
+        return;
+    }
+
     BufferDataLayout layout{
             {"vertex positions",      vertexType::Float3},
             {"vertex normals",        vertexType::Float3},

--- a/Agate/src/Agate/Rendering/Mesh.cpp
+++ b/Agate/src/Agate/Rendering/Mesh.cpp
@@ -69,7 +69,7 @@ void Mesh::Draw(Agate::Shader &shader) {
 
     // draw mesh
     m_VA->Bind();
-    glDrawElements(GL_TRIANGLES, m_indices.size(), GL_UNSIGNED_INT, 0);
+    glDrawElements(GL_TRIANGLES, static_cast<GLsizei>(m_indices.size()), GL_UNSIGNED_INT, 0);
     m_VA->UnBind();
 }
 

--- a/Agate/src/Agate/Rendering/Mesh.cpp
+++ b/Agate/src/Agate/Rendering/Mesh.cpp
@@ -5,9 +5,9 @@
 namespace Agate {
 
 Mesh::Mesh(std::vector<Vertex> vertices, std::vector<unsigned int> indices, std::vector<Texture> textures) {
-    this->vertices = std::move(vertices);
-    this->indices = std::move(indices);
-    this->textures = std::move(textures);
+    this->m_vertices = std::move(vertices);
+    this->m_indices = std::move(indices);
+    this->m_textures = std::move(textures);
 
     setupMesh();
 }
@@ -23,11 +23,11 @@ void Mesh::Draw(Agate::Shader &shader) {
 
     shader.Bind();
     // Activate and bind each texture, assign to the shader
-    for (unsigned int i = 0; i < textures.size(); i++) {
+    for (unsigned int i = 0; i < m_textures.size(); i++) {
         glActiveTexture(GL_TEXTURE0 + i); // Activate texture unit
-        textures[i].bind(i); // Bind texture to unit i
+        m_textures[i].bind(i); // Bind texture to unit i
 
-        std::string type = textures[i].getType();
+        std::string type = m_textures[i].getType();
         std::string name;
         if (type == "texture_diffuse") {
             name = "material.texture_diffuse[" + std::to_string(diffuseCount) + "]";
@@ -68,9 +68,9 @@ void Mesh::Draw(Agate::Shader &shader) {
     glActiveTexture(GL_TEXTURE0);
 
     // draw mesh
-    VA->Bind();
-    glDrawElements(GL_TRIANGLES, indices.size(), GL_UNSIGNED_INT, 0);
-    VA->UnBind();
+    m_VA->Bind();
+    glDrawElements(GL_TRIANGLES, m_indices.size(), GL_UNSIGNED_INT, 0);
+    m_VA->UnBind();
 }
 
 void Mesh::setupMesh() {
@@ -83,10 +83,10 @@ void Mesh::setupMesh() {
             {"BiTangent",             vertexType::Float3},
     };
 
-    IndexBuffer IB(indices);
+    IndexBuffer IB(m_indices);
 
-    VA = std::make_shared<VertexArray>(layout, &vertices[0], vertices.size() * sizeof(Vertex));
-    VA->addIndexBuffer(IB);
+    m_VA = std::make_shared<VertexArray>(layout, &m_vertices[0], m_vertices.size() * sizeof(Vertex));
+    m_VA->addIndexBuffer(IB);
 }
 
 Mesh::~Mesh() = default;

--- a/Agate/src/Agate/Rendering/Mesh.cpp
+++ b/Agate/src/Agate/Rendering/Mesh.cpp
@@ -1,0 +1,94 @@
+#include "Mesh.h"
+#include "OpenGl/VertexArray.h"
+#include "glad/glad.h"
+
+namespace Agate {
+
+Mesh::Mesh(std::vector<Vertex> vertices, std::vector<unsigned int> indices, std::vector<Texture> textures) {
+    this->vertices = std::move(vertices);
+    this->indices = std::move(indices);
+    this->textures = std::move(textures);
+
+    setupMesh();
+}
+
+//@todo we should not really render here
+void Mesh::Draw(Agate::Shader &shader) {
+
+    // Initialize texture counters
+    int diffuseCount = 0;
+    int specularCount = 0;
+    int normalCount = 0;
+    int heightCount = 0;
+
+    shader.Bind();
+    // Activate and bind each texture, assign to the shader
+    for (unsigned int i = 0; i < textures.size(); i++) {
+        glActiveTexture(GL_TEXTURE0 + i); // Activate texture unit
+        textures[i].bind(i); // Bind texture to unit i
+
+        std::string type = textures[i].getType();
+        std::string name;
+        if (type == "texture_diffuse") {
+            name = "material.texture_diffuse[" + std::to_string(diffuseCount) + "]";
+            shader.SetUniform1i(name.c_str(), i);
+            diffuseCount++;
+        }
+        else if (type == "texture_specular") {
+            name = "material.texture_specular[" + std::to_string(specularCount) + "]";
+            shader.SetUniform1i(name.c_str(), i);
+            specularCount++;
+        }
+        else if (type == "texture_normal") {
+            name = "material.texture_normal[" + std::to_string(normalCount) + "]";
+            shader.SetUniform1i(name.c_str(), i);
+            normalCount++;
+        }
+        else if (type == "texture_height") {
+            name = "material.texture_height[" + std::to_string(heightCount) + "]";
+            shader.SetUniform1i(name.c_str(), i);
+            heightCount++;
+        }
+    }
+
+    // Set the counts in the shader
+    shader.SetUniform1i("material.num_diffuse", diffuseCount);
+    shader.SetUniform1i("material.num_specular", specularCount);
+    shader.SetUniform1i("material.num_normal", normalCount);
+    shader.SetUniform1i("material.num_height", heightCount);
+
+    // Set light properties
+    shader.SetUniform3f("pointLight.Color", 1.0f, 1.0f, 1.0f);           // Color: White light
+    shader.SetUniform1f("pointLight.Intensity", 5.0f);                              // Intensity: Standard brightness
+    shader.SetUniform1f("pointLight.Constant", 1.0f);                               // Attenuation: Constant factor
+    shader.SetUniform1f("pointLight.Linear", .09f);                                // Attenuation: Linear factor
+    shader.SetUniform1f("pointLight.Quadratic", 0.032f);                           // Attenuation: Quadratic factor
+
+    //don't think this line is needed
+    glActiveTexture(GL_TEXTURE0);
+
+    // draw mesh
+    VA->Bind();
+    glDrawElements(GL_TRIANGLES, indices.size(), GL_UNSIGNED_INT, 0);
+    VA->UnBind();
+}
+
+void Mesh::setupMesh() {
+
+    BufferDataLayout layout{
+            {"vertex positions",      vertexType::Float3},
+            {"vertex normals",        vertexType::Float3},
+            {"vertex texture coords", vertexType::Float2},
+            {"tangent",               vertexType::Float3},
+            {"BiTangent",             vertexType::Float3},
+    };
+
+    IndexBuffer IB(indices);
+
+    VA = std::make_shared<VertexArray>(layout, &vertices[0], vertices.size() * sizeof(Vertex));
+    VA->addIndexBuffer(IB);
+}
+
+Mesh::~Mesh() = default;
+
+} // namespace Agate

--- a/Agate/src/Agate/Rendering/Mesh.cpp
+++ b/Agate/src/Agate/Rendering/Mesh.cpp
@@ -89,7 +89,7 @@ void Mesh::setupMesh() {
 
     IndexBuffer IB(m_indices);
 
-    m_VA = std::make_shared<VertexArray>(layout, &m_vertices[0], m_vertices.size() * sizeof(Vertex));
+    m_VA = std::make_shared<VertexArray>(layout, m_vertices.data(), m_vertices.size() * sizeof(Vertex));
     m_VA->addIndexBuffer(IB);
 }
 

--- a/Agate/src/Agate/Rendering/Mesh.h
+++ b/Agate/src/Agate/Rendering/Mesh.h
@@ -1,0 +1,66 @@
+/**
+ * @brief Include file for the Mesh class
+ * 
+ * Has render data for OpenGL and the ability to invoke OpenGL
+ * to draw itself
+ */
+
+#ifndef AGATE_MESH_H
+#define AGATE_MESH_H
+
+#include "OpenGl/Shader.h"
+#include "OpenGl/Texture.h"
+#include "OpenGl/VertexArray.h"
+#include <glm/glm.hpp>
+#include <memory>
+#include <vector>
+
+namespace Agate {
+
+/**
+ * @brief A vertex with a position, normal, texture coordinate,
+ *        tanget, and bitangent
+ */
+struct Vertex {
+    glm::vec3 Position;
+    glm::vec3 Normal;
+    glm::vec2 TexCoords;
+    glm::vec3 Tangent;
+    glm::vec3 Bitangent;
+};
+
+class Mesh {
+public:
+
+    std::vector<Vertex> vertices;
+    std::vector<unsigned int> indices;
+    std::vector<Texture> textures;
+
+    /**
+     * @brief Constructor from mesh data
+     * 
+     * @param vertices Vertices that make up the mesh
+     * @param indices Relative indices of the mesh vertices to map to faces
+     * @param textures Textures required by this mesh
+     */
+    Mesh(std::vector<Vertex> vertices, std::vector<unsigned int> indices, std::vector<Texture> textures);
+
+    /**
+     * @brief Draws this mesh
+     * 
+     * @param shader Shader to bind and use for shading the mesh
+     */
+    void Draw(Shader &shader);
+
+    virtual ~Mesh();
+
+private:
+    //  render data
+    std::shared_ptr<VertexArray> VA;
+
+    void setupMesh();
+};
+
+}
+
+#endif // AGATE_MESH_H

--- a/Agate/src/Agate/Rendering/Mesh.h
+++ b/Agate/src/Agate/Rendering/Mesh.h
@@ -19,7 +19,7 @@ namespace Agate {
 
 /**
  * @brief A vertex with a position, normal, texture coordinate,
- *        tanget, and bitangent
+ *        tangent, and bitangent
  */
 struct Vertex {
     glm::vec3 Position;

--- a/Agate/src/Agate/Rendering/Mesh.h
+++ b/Agate/src/Agate/Rendering/Mesh.h
@@ -32,9 +32,9 @@ struct Vertex {
 class Mesh {
 public:
 
-    std::vector<Vertex> vertices;
-    std::vector<unsigned int> indices;
-    std::vector<Texture> textures;
+    std::vector<Vertex> m_vertices;
+    std::vector<unsigned int> m_indices;
+    std::vector<Texture> m_textures;
 
     /**
      * @brief Constructor from mesh data
@@ -56,7 +56,7 @@ public:
 
 private:
     //  render data
-    std::shared_ptr<VertexArray> VA;
+    std::shared_ptr<VertexArray> m_VA;
 
     void setupMesh();
 };

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -65,80 +65,12 @@ void Agate::ModelLoader::processNode(aiNode *node, const aiScene *scene, const g
     // process each mesh located at the current node
     for (unsigned int i = 0; i < node->mNumMeshes; i++) {
         aiMesh *mesh = scene->mMeshes[node->mMeshes[i]];
-        m_meshes.push_back(processMesh(mesh, scene, nodeTransform));
+        m_meshes.push_back(assimp.processMesh(mesh, scene, nodeTransform, textures_loaded));
     }
     // after we've processed all of the meshes (if any) we then recursively process each of the children nodes
     for (unsigned int i = 0; i < node->mNumChildren; i++) {
         processNode(node->mChildren[i], scene, nodeTransform);
     }
-}
-
-Agate::Mesh Agate::ModelLoader::processMesh(aiMesh *mesh, const aiScene *scene, const glm::mat4 &transform) {
-    // data to fill
-    std::vector<Vertex> vertices;
-    std::vector<unsigned int> indices;
-    std::vector<Texture> textures;
-
-    // walk through each of the mesh's vertices
-    for (unsigned int i = 0; i < mesh->mNumVertices; i++) {
-        Vertex vertex;
-        glm::vec3 vector;
-        // positions
-        vector.x = mesh->mVertices[i].x;
-        vector.y = mesh->mVertices[i].y;
-        vector.z = mesh->mVertices[i].z;
-        vertex.Position = glm::vec3(transform * glm::vec4(vector, 1.0f));
-        // normals
-        if (mesh->HasNormals()) {
-            vector.x = mesh->mNormals[i].x;
-            vector.y = mesh->mNormals[i].y;
-            vector.z = mesh->mNormals[i].z;
-            vertex.Normal = glm::mat3(transform) * vector;
-        }
-        // texture coordinates
-        if (mesh->mTextureCoords[0]) {
-            glm::vec2 vec;
-            vec.x = mesh->mTextureCoords[0][i].x;
-            vec.y = mesh->mTextureCoords[0][i].y;
-            vertex.TexCoords = vec;
-            // tangent
-            vector.x = mesh->mTangents[i].x;
-            vector.y = mesh->mTangents[i].y;
-            vector.z = mesh->mTangents[i].z;
-            vertex.Tangent = glm::mat3(transform) * vector;
-            // bitangent
-            vector.x = mesh->mBitangents[i].x;
-            vector.y = mesh->mBitangents[i].y;
-            vector.z = mesh->mBitangents[i].z;
-            vertex.Bitangent = glm::mat3(transform) * vector;
-        } else {
-            vertex.TexCoords = glm::vec2(0.0f, 0.0f);
-        }
-
-        vertices.push_back(vertex);
-    }
-    // now walk through each of the mesh's faces (a face is a mesh its triangle) and retrieve the corresponding vertex indices.
-    for (unsigned int i = 0; i < mesh->mNumFaces; i++) {
-        aiFace face = mesh->mFaces[i];
-        for (unsigned int j = 0; j < face.mNumIndices; j++)
-            indices.push_back(face.mIndices[j]);
-    }
-    // process materials
-    aiMaterial *material = scene->mMaterials[mesh->mMaterialIndex];
-
-    std::vector<Texture> diffuseMaps = assimp.loadMaterialTextures(material, aiTextureType_DIFFUSE, "texture_diffuse", textures_loaded);
-    textures.insert(textures.end(), diffuseMaps.begin(), diffuseMaps.end());
-
-    std::vector<Texture> specularMaps = assimp.loadMaterialTextures(material, aiTextureType_SPECULAR, "texture_specular", textures_loaded);
-    textures.insert(textures.end(), specularMaps.begin(), specularMaps.end());
-
-    std::vector<Texture> normalMaps = assimp.loadMaterialTextures(material, aiTextureType_HEIGHT, "texture_normal", textures_loaded);
-    textures.insert(textures.end(), normalMaps.begin(), normalMaps.end());
-
-    std::vector<Texture> heightMaps = assimp.loadMaterialTextures(material, aiTextureType_AMBIENT, "texture_height", textures_loaded);
-    textures.insert(textures.end(), heightMaps.begin(), heightMaps.end());
-
-    return Mesh{vertices, indices, textures};
 }
 
 std::string Agate::ModelLoader::extractDirectory(const std::string &path) {

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -5,13 +5,8 @@
 
 namespace fs = std::filesystem;
 
-Agate::ModelLoader::ModelLoader(std::string const &path, bool flipUVs)
-    : m_directory(extractDirectory(path)), m_path(path), assimp(extractDirectory(path), path, flipUVs) {
-
-    // This future is used to async load the data of the model file
-    m_futureScene = assimp.readFile(); 
-
-}
+Agate::ModelLoader::ModelLoader(std::string const &path)
+    : m_directory(extractDirectory(path)), m_path(path) {}
 
 void Agate::ModelLoader::Draw(Agate::Shader &shader) {
 
@@ -22,12 +17,16 @@ void Agate::ModelLoader::Draw(Agate::Shader &shader) {
         if (status == std::future_status::ready) {
             // Once this is done the future scene will no longer be valid
             m_futureScene.get();
-            m_meshes = assimp.prepareScene(textures_loaded);
+            m_meshes = parseModel();
         }
     }
 
     for (auto &mesh: m_meshes)
         mesh.Draw(shader);
+}
+
+void Agate::ModelLoader::LoadModel() {
+    m_futureScene = loadModel();
 }
 
 std::string Agate::ModelLoader::extractDirectory(const std::string &path) {

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -1,7 +1,9 @@
 #include "agpch.h"
 #include "ModelLoader.h"
+#include "AssimpLoader.h"
 #include "Mesh.h"
 #include <utility>
+#include <memory>
 
 namespace fs = std::filesystem;
 
@@ -25,8 +27,12 @@ void Agate::ModelLoader::Draw(Agate::Shader &shader) {
         mesh.Draw(shader);
 }
 
-void Agate::ModelLoader::LoadModel() {
-    m_futureScene = loadModel();
+std::unique_ptr<Agate::ModelLoader> Agate::ModelLoader::LoadModel(const std::string &path) {
+
+    std::unique_ptr<Agate::ModelLoader> loader{ new AssimpLoader(path) };
+    loader->m_futureScene = loader->loadModel();
+
+    return loader;
 }
 
 std::string Agate::ModelLoader::extractDirectory(const std::string &path) {

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -10,7 +10,7 @@ namespace fs = std::filesystem;
 Agate::ModelLoader::~ModelLoader() {
 
     // Block until asynchronous load is finished, if applicable
-    if (m_startedLoad && m_futureScene.valid()) {
+    if (m_futureScene.valid()) {
         m_futureScene.wait();
     }
 }
@@ -41,7 +41,6 @@ void Agate::ModelLoader::Draw(Agate::Shader &shader) {
 std::unique_ptr<Agate::ModelLoader> Agate::ModelLoader::LoadModel(const std::string &path) {
 
     std::unique_ptr<Agate::ModelLoader> loader = std::make_unique<AssimpLoader>(path);
-    loader->m_startedLoad = true;
     loader->m_futureScene = loader->loadModel();
 
     return loader;

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -21,6 +21,7 @@ void Agate::ModelLoader::Draw(Agate::Shader &shader) {
         auto status = m_futureScene.wait_for(std::chrono::seconds(0));
         if (status == std::future_status::ready) {
             // Once this is done the future scene will no longer be valid
+            m_futureScene.get();
             m_meshes = assimp.prepareScene(textures_loaded);
         }
     }

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -9,12 +9,10 @@
 namespace fs = std::filesystem;
 
 Agate::ModelLoader::ModelLoader(std::string const &path, bool flipUVs)
-    : m_directory(extractDirectory(path)), m_path(path), assimp(extractDirectory(path), path) {
-    // read file via ASSIMP
-    unsigned int assimpFlags = assimp.getFlags(flipUVs);
+    : m_directory(extractDirectory(path)), m_path(path), assimp(extractDirectory(path), path, flipUVs) {
 
     // This future is used to async load the data of the model file
-    m_futureScene = assimp.readFile(assimpFlags); 
+    m_futureScene = assimp.readFile(); 
 
 }
 

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -1,5 +1,6 @@
 #include "agpch.h"
 #include "ModelLoader.h"
+#include "AssimpLoader.h"
 #include "Agate/Core/Logger.h"
 #include "assimp/scene.h"
 #include "glad/glad.h"
@@ -111,7 +112,8 @@ Agate::Mesh::~Mesh() = default;
 Agate::ModelLoader::ModelLoader(std::string const &path, bool gamma, bool flipUVs)
     : m_directory(extractDirectory(path)),m_path(path), m_gammaCorrection(gamma){
     // read file via ASSIMP
-    unsigned int assimpFlags = this->getAssimpFlags(flipUVs);
+    Agate::AssimpLoader assimp{};
+    unsigned int assimpFlags = assimp.getFlags(flipUVs);
 
     // This future is used to async load the data of the model file
     m_futureScene = std::async(std::launch::async, [this, assimpFlags]() {
@@ -145,19 +147,6 @@ void Agate::ModelLoader::prepareScene(const aiScene *scene) {
             // Proccess the nodes once (Note this can be very expensive)
             processNode(scene->mRootNode, scene, glm::mat4(1.0f));
             PRINTMSG("Model loaded from path: {}", m_path);
-}
-
-unsigned int Agate::ModelLoader::getAssimpFlags(bool flipUVs) {
-    // read file via ASSIMP
-    unsigned int assimpFlags = aiProcess_CalcTangentSpace         |
-                               aiProcess_Triangulate             |
-                               aiProcess_JoinIdenticalVertices   |
-                               aiProcess_SortByPType;
-
-    if(flipUVs) {
-        assimpFlags |= aiProcess_FlipUVs;
-    }
-    return assimpFlags;
 }
 
 void Agate::ModelLoader::processNode(aiNode *node, const aiScene *scene, const glm::mat4 &parentTransform) {

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -1,9 +1,9 @@
 #include "agpch.h"
 #include "ModelLoader.h"
 #include "Agate/Core/Logger.h"
+#include "Mesh.h"
 #include "assimp/scene.h"
 #include "glad/glad.h"
-#include "OpenGl/VertexArray.h"
 #include <utility>
 
 namespace fs = std::filesystem;
@@ -20,93 +20,6 @@ inline glm::mat4 convertMatrix(const aiMatrix4x4 &matrix) {
                      matrix.a3, matrix.b3, matrix.c3, matrix.d3,
                      matrix.a4, matrix.b4, matrix.c4, matrix.d4);
 }
-
-Agate::Mesh::Mesh(std::vector<Vertex> vertices, std::vector<unsigned int> indices, std::vector<Texture> textures) {
-    this->vertices = std::move(vertices);
-    this->indices = std::move(indices);
-    this->textures = std::move(textures);
-
-    setupMesh();
-}
-
-//@todo we should not really render here
-void Agate::Mesh::Draw(Agate::Shader &shader) {
-
-    // Initialize texture counters
-    int diffuseCount = 0;
-    int specularCount = 0;
-    int normalCount = 0;
-    int heightCount = 0;
-
-    shader.Bind();
-    // Activate and bind each texture, assign to the shader
-    for (unsigned int i = 0; i < textures.size(); i++) {
-        glActiveTexture(GL_TEXTURE0 + i); // Activate texture unit
-        textures[i].bind(i); // Bind texture to unit i
-
-        std::string type = textures[i].getType();
-        std::string name;
-        if (type == "texture_diffuse") {
-            name = "material.texture_diffuse[" + std::to_string(diffuseCount) + "]";
-            shader.SetUniform1i(name.c_str(), i);
-            diffuseCount++;
-        }
-        else if (type == "texture_specular") {
-            name = "material.texture_specular[" + std::to_string(specularCount) + "]";
-            shader.SetUniform1i(name.c_str(), i);
-            specularCount++;
-        }
-        else if (type == "texture_normal") {
-            name = "material.texture_normal[" + std::to_string(normalCount) + "]";
-            shader.SetUniform1i(name.c_str(), i);
-            normalCount++;
-        }
-        else if (type == "texture_height") {
-            name = "material.texture_height[" + std::to_string(heightCount) + "]";
-            shader.SetUniform1i(name.c_str(), i);
-            heightCount++;
-        }
-    }
-
-    // Set the counts in the shader
-    shader.SetUniform1i("material.num_diffuse", diffuseCount);
-    shader.SetUniform1i("material.num_specular", specularCount);
-    shader.SetUniform1i("material.num_normal", normalCount);
-    shader.SetUniform1i("material.num_height", heightCount);
-
-    // Set light properties
-    shader.SetUniform3f("pointLight.Color", 1.0f, 1.0f, 1.0f);           // Color: White light
-    shader.SetUniform1f("pointLight.Intensity", 5.0f);                              // Intensity: Standard brightness
-    shader.SetUniform1f("pointLight.Constant", 1.0f);                               // Attenuation: Constant factor
-    shader.SetUniform1f("pointLight.Linear", .09f);                                // Attenuation: Linear factor
-    shader.SetUniform1f("pointLight.Quadratic", 0.032f);                           // Attenuation: Quadratic factor
-
-    //don't think this line is needed
-    glActiveTexture(GL_TEXTURE0);
-
-    // draw mesh
-    VA->Bind();
-    glDrawElements(GL_TRIANGLES, indices.size(), GL_UNSIGNED_INT, 0);
-    VA->UnBind();
-}
-
-void Agate::Mesh::setupMesh() {
-
-    BufferDataLayout layout{
-            {"vertex positions",      vertexType::Float3},
-            {"vertex normals",        vertexType::Float3},
-            {"vertex texture coords", vertexType::Float2},
-            {"tangent",               vertexType::Float3},
-            {"BiTangent",             vertexType::Float3},
-    };
-
-    IndexBuffer IB(indices);
-
-    VA = std::make_shared<VertexArray>(layout, &vertices[0], vertices.size() * sizeof(Vertex));
-    VA->addIndexBuffer(IB);
-}
-
-Agate::Mesh::~Mesh() = default;
 
 Agate::ModelLoader::ModelLoader(std::string const &path, bool flipUVs)
     : m_directory(extractDirectory(path)), m_path(path), assimp(extractDirectory(path)) {

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -29,7 +29,7 @@ void Agate::ModelLoader::Draw(Agate::Shader &shader) {
 
 std::unique_ptr<Agate::ModelLoader> Agate::ModelLoader::LoadModel(const std::string &path) {
 
-    std::unique_ptr<Agate::ModelLoader> loader{ new AssimpLoader(path) };
+    std::unique_ptr<Agate::ModelLoader> loader = std::make_unique<AssimpLoader>(path);
     loader->m_futureScene = loader->loadModel();
 
     return loader;

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -1,9 +1,6 @@
 #include "agpch.h"
 #include "ModelLoader.h"
-#include "Agate/Core/Logger.h"
 #include "Mesh.h"
-#include "assimp/scene.h"
-#include "glad/glad.h"
 #include <utility>
 
 namespace fs = std::filesystem;
@@ -24,7 +21,7 @@ void Agate::ModelLoader::Draw(Agate::Shader &shader) {
         auto status = m_futureScene.wait_for(std::chrono::seconds(0));
         if (status == std::future_status::ready) {
             // Once this is done the future scene will no longer be valid
-            m_meshes = assimp.prepareScene(m_futureScene.get(), textures_loaded);
+            m_meshes = assimp.prepareScene(textures_loaded);
         }
     }
 

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -1,6 +1,5 @@
 #include "agpch.h"
 #include "ModelLoader.h"
-#include "AssimpLoader.h"
 #include "Agate/Core/Logger.h"
 #include "assimp/scene.h"
 #include "glad/glad.h"
@@ -112,12 +111,10 @@ Agate::Mesh::~Mesh() = default;
 Agate::ModelLoader::ModelLoader(std::string const &path, bool gamma, bool flipUVs)
     : m_directory(extractDirectory(path)),m_path(path), m_gammaCorrection(gamma){
     // read file via ASSIMP
-    Agate::AssimpLoader assimp{};
     unsigned int assimpFlags = assimp.getFlags(flipUVs);
 
     // This future is used to async load the data of the model file
-    m_futureScene = std::async(std::launch::async, [this, assimpFlags]() {
-                    return m_importer.ReadFile(m_path, assimpFlags);}); 
+    m_futureScene = assimp.readFile(m_path, assimpFlags); 
 
 }
 
@@ -139,8 +136,8 @@ void Agate::ModelLoader::Draw(Agate::Shader &shader) {
 
 void Agate::ModelLoader::prepareScene(const aiScene *scene) {
             // Is the scene valid?
-            if (!scene || scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE || !scene->mRootNode) {
-                PRINTERROR("ASSIMP ERROR: {}", m_importer.GetErrorString());
+            if (!scene) {
+                PRINTERROR("No scene to prepare");
                 return;
             }
 

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -26,25 +26,12 @@ void Agate::ModelLoader::Draw(Agate::Shader &shader) {
         auto status = m_futureScene.wait_for(std::chrono::seconds(0));
         if (status == std::future_status::ready) {
             // Once this is done the future scene will no longer be valid
-            prepareScene(m_futureScene.get());
+            assimp.prepareScene(m_futureScene.get(), m_path, textures_loaded);
         }
     }
 
     for (auto &mesh: m_meshes)
         mesh.Draw(shader);
-}
-
-void Agate::ModelLoader::prepareScene(const aiScene *scene) {
-            // Is the scene valid?
-            if (!scene) {
-                PRINTERROR("No scene to prepare");
-                return;
-            }
-
-            // Proccess the nodes once (Note this can be very expensive)
-            std::vector<Mesh> nodeMeshes = assimp.processNode(scene->mRootNode, scene, glm::mat4(1.0f), textures_loaded);
-            m_meshes.insert(m_meshes.end(), nodeMeshes.begin(), nodeMeshes.end());
-            PRINTMSG("Model loaded from path: {}", m_path);
 }
 
 std::string Agate::ModelLoader::extractDirectory(const std::string &path) {

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -109,7 +109,7 @@ void Agate::Mesh::setupMesh() {
 Agate::Mesh::~Mesh() = default;
 
 Agate::ModelLoader::ModelLoader(std::string const &path, bool flipUVs)
-    : m_directory(extractDirectory(path)),m_path(path) {
+    : m_directory(extractDirectory(path)), m_path(path), assimp(extractDirectory(path)) {
     // read file via ASSIMP
     unsigned int assimpFlags = assimp.getFlags(flipUVs);
 
@@ -213,16 +213,16 @@ Agate::Mesh Agate::ModelLoader::processMesh(aiMesh *mesh, const aiScene *scene, 
     // process materials
     aiMaterial *material = scene->mMaterials[mesh->mMaterialIndex];
 
-    std::vector<Texture> diffuseMaps = assimp.loadMaterialTextures(material, aiTextureType_DIFFUSE, "texture_diffuse", m_directory, textures_loaded);
+    std::vector<Texture> diffuseMaps = assimp.loadMaterialTextures(material, aiTextureType_DIFFUSE, "texture_diffuse", textures_loaded);
     textures.insert(textures.end(), diffuseMaps.begin(), diffuseMaps.end());
 
-    std::vector<Texture> specularMaps = assimp.loadMaterialTextures(material, aiTextureType_SPECULAR, "texture_specular", m_directory, textures_loaded);
+    std::vector<Texture> specularMaps = assimp.loadMaterialTextures(material, aiTextureType_SPECULAR, "texture_specular", textures_loaded);
     textures.insert(textures.end(), specularMaps.begin(), specularMaps.end());
 
-    std::vector<Texture> normalMaps = assimp.loadMaterialTextures(material, aiTextureType_HEIGHT, "texture_normal", m_directory, textures_loaded);
+    std::vector<Texture> normalMaps = assimp.loadMaterialTextures(material, aiTextureType_HEIGHT, "texture_normal", textures_loaded);
     textures.insert(textures.end(), normalMaps.begin(), normalMaps.end());
 
-    std::vector<Texture> heightMaps = assimp.loadMaterialTextures(material, aiTextureType_AMBIENT, "texture_height", m_directory, textures_loaded);
+    std::vector<Texture> heightMaps = assimp.loadMaterialTextures(material, aiTextureType_AMBIENT, "texture_height", textures_loaded);
     textures.insert(textures.end(), heightMaps.begin(), heightMaps.end());
 
     return Mesh{vertices, indices, textures};

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -8,19 +8,6 @@
 
 namespace fs = std::filesystem;
 
-/*
- * Convert an assimp matrix to a glm matrix, this is the best way I can find to do this
- *
- * @param matrix The assimp matrix to convert
- * @return The converted glm matrix
- */
-inline glm::mat4 convertMatrix(const aiMatrix4x4 &matrix) {
-    return glm::mat4(matrix.a1, matrix.b1, matrix.c1, matrix.d1,
-                     matrix.a2, matrix.b2, matrix.c2, matrix.d2,
-                     matrix.a3, matrix.b3, matrix.c3, matrix.d3,
-                     matrix.a4, matrix.b4, matrix.c4, matrix.d4);
-}
-
 Agate::ModelLoader::ModelLoader(std::string const &path, bool flipUVs)
     : m_directory(extractDirectory(path)), m_path(path), assimp(extractDirectory(path)) {
     // read file via ASSIMP
@@ -55,22 +42,9 @@ void Agate::ModelLoader::prepareScene(const aiScene *scene) {
             }
 
             // Proccess the nodes once (Note this can be very expensive)
-            processNode(scene->mRootNode, scene, glm::mat4(1.0f));
+            std::vector<Mesh> nodeMeshes = assimp.processNode(scene->mRootNode, scene, glm::mat4(1.0f), textures_loaded);
+            m_meshes.insert(m_meshes.end(), nodeMeshes.begin(), nodeMeshes.end());
             PRINTMSG("Model loaded from path: {}", m_path);
-}
-
-void Agate::ModelLoader::processNode(aiNode *node, const aiScene *scene, const glm::mat4 &parentTransform) {
-    glm::mat4 nodeTransform = parentTransform * convertMatrix(node->mTransformation);
-
-    // process each mesh located at the current node
-    for (unsigned int i = 0; i < node->mNumMeshes; i++) {
-        aiMesh *mesh = scene->mMeshes[node->mMeshes[i]];
-        m_meshes.push_back(assimp.processMesh(mesh, scene, nodeTransform, textures_loaded));
-    }
-    // after we've processed all of the meshes (if any) we then recursively process each of the children nodes
-    for (unsigned int i = 0; i < node->mNumChildren; i++) {
-        processNode(node->mChildren[i], scene, nodeTransform);
-    }
 }
 
 std::string Agate::ModelLoader::extractDirectory(const std::string &path) {

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -24,7 +24,7 @@ void Agate::ModelLoader::Draw(Agate::Shader &shader) {
         auto status = m_futureScene.wait_for(std::chrono::seconds(0));
         if (status == std::future_status::ready) {
             // Once this is done the future scene will no longer be valid
-            assimp.prepareScene(m_futureScene.get(), textures_loaded);
+            m_meshes = assimp.prepareScene(m_futureScene.get(), textures_loaded);
         }
     }
 

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -18,8 +18,11 @@ void Agate::ModelLoader::Draw(Agate::Shader &shader) {
         auto status = m_futureScene.wait_for(std::chrono::seconds(0));
         if (status == std::future_status::ready) {
             // Once this is done the future scene will no longer be valid
-            m_futureScene.get();
-            m_meshes = parseModel();
+            if (m_futureScene.get()) {
+                m_meshes = parseModel();
+            } else {
+                PRINTWARN("ModelLoader: Model load failed");
+            }
         }
     }
 

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -213,42 +213,19 @@ Agate::Mesh Agate::ModelLoader::processMesh(aiMesh *mesh, const aiScene *scene, 
     // process materials
     aiMaterial *material = scene->mMaterials[mesh->mMaterialIndex];
 
-    std::vector<Texture> diffuseMaps = loadMaterialTextures(material, aiTextureType_DIFFUSE, "texture_diffuse");
+    std::vector<Texture> diffuseMaps = assimp.loadMaterialTextures(material, aiTextureType_DIFFUSE, "texture_diffuse", m_directory, textures_loaded);
     textures.insert(textures.end(), diffuseMaps.begin(), diffuseMaps.end());
 
-    std::vector<Texture> specularMaps = loadMaterialTextures(material, aiTextureType_SPECULAR, "texture_specular");
+    std::vector<Texture> specularMaps = assimp.loadMaterialTextures(material, aiTextureType_SPECULAR, "texture_specular", m_directory, textures_loaded);
     textures.insert(textures.end(), specularMaps.begin(), specularMaps.end());
 
-    std::vector<Texture> normalMaps = loadMaterialTextures(material, aiTextureType_HEIGHT, "texture_normal");
+    std::vector<Texture> normalMaps = assimp.loadMaterialTextures(material, aiTextureType_HEIGHT, "texture_normal", m_directory, textures_loaded);
     textures.insert(textures.end(), normalMaps.begin(), normalMaps.end());
 
-    std::vector<Texture> heightMaps = loadMaterialTextures(material, aiTextureType_AMBIENT, "texture_height");
+    std::vector<Texture> heightMaps = assimp.loadMaterialTextures(material, aiTextureType_AMBIENT, "texture_height", m_directory, textures_loaded);
     textures.insert(textures.end(), heightMaps.begin(), heightMaps.end());
 
     return Mesh{vertices, indices, textures};
-}
-
-std::vector<Agate::Texture> Agate::ModelLoader::loadMaterialTextures(aiMaterial *mat, aiTextureType type, std::string typeName) {
-    std::vector<Texture> textures;
-    for (unsigned int i = 0; i < mat->GetTextureCount(type); i++) {
-        aiString str;
-        mat->GetTexture(type, i, &str);
-        bool skip = false;
-        for (auto &j: textures_loaded) {
-            if (std::strcmp(j.getPath().data(), str.C_Str()) == 0) {
-                textures.push_back(j);
-                skip = true;
-                break;
-            }
-        }
-        if (!skip) {
-            Texture texture(str.C_Str(), this->m_directory);
-            texture.setType(typeName);
-            textures.push_back(texture);
-            textures_loaded.push_back(texture);
-        }
-    }
-    return std::move(textures);
 }
 
 std::string Agate::ModelLoader::extractDirectory(const std::string &path) {

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -9,12 +9,12 @@
 namespace fs = std::filesystem;
 
 Agate::ModelLoader::ModelLoader(std::string const &path, bool flipUVs)
-    : m_directory(extractDirectory(path)), m_path(path), assimp(extractDirectory(path)) {
+    : m_directory(extractDirectory(path)), m_path(path), assimp(extractDirectory(path), path) {
     // read file via ASSIMP
     unsigned int assimpFlags = assimp.getFlags(flipUVs);
 
     // This future is used to async load the data of the model file
-    m_futureScene = assimp.readFile(m_path, assimpFlags); 
+    m_futureScene = assimp.readFile(assimpFlags); 
 
 }
 
@@ -26,7 +26,7 @@ void Agate::ModelLoader::Draw(Agate::Shader &shader) {
         auto status = m_futureScene.wait_for(std::chrono::seconds(0));
         if (status == std::future_status::ready) {
             // Once this is done the future scene will no longer be valid
-            assimp.prepareScene(m_futureScene.get(), m_path, textures_loaded);
+            assimp.prepareScene(m_futureScene.get(), textures_loaded);
         }
     }
 

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -7,6 +7,14 @@
 
 namespace fs = std::filesystem;
 
+Agate::ModelLoader::~ModelLoader() {
+
+    // Block until asynchronous load is finished, if applicable
+    if (m_startedLoad && m_futureScene.valid()) {
+        m_futureScene.wait();
+    }
+}
+
 Agate::ModelLoader::ModelLoader(std::string const &path)
     : m_directory(extractDirectory(path)), m_path(path) {}
 
@@ -33,6 +41,7 @@ void Agate::ModelLoader::Draw(Agate::Shader &shader) {
 std::unique_ptr<Agate::ModelLoader> Agate::ModelLoader::LoadModel(const std::string &path) {
 
     std::unique_ptr<Agate::ModelLoader> loader = std::make_unique<AssimpLoader>(path);
+    loader->m_startedLoad = true;
     loader->m_futureScene = loader->loadModel();
 
     return loader;

--- a/Agate/src/Agate/Rendering/ModelLoader.h
+++ b/Agate/src/Agate/Rendering/ModelLoader.h
@@ -1,11 +1,11 @@
 #ifndef AGATE_MODELLOADER_H
 #define AGATE_MODELLOADER_H
 
+#include "AssimpLoader.h"
 #include "OpenGl/Shader.h"
 #include "OpenGl/VertexArray.h"
 #include "OpenGl/Texture.h"
 #include <glm/glm.hpp>
-#include <assimp/Importer.hpp>
 #include <assimp/scene.h>
 #include <future>
 
@@ -89,7 +89,7 @@ namespace Agate {
 
     private:
         // this future is used to load the model independent of the main thread
-        Assimp::Importer m_importer;
+        AssimpLoader assimp;
         std::future<const aiScene*> m_futureScene;
 
     private:

--- a/Agate/src/Agate/Rendering/ModelLoader.h
+++ b/Agate/src/Agate/Rendering/ModelLoader.h
@@ -2,8 +2,8 @@
 #define AGATE_MODELLOADER_H
 
 #include "AssimpLoader.h"
+#include "Mesh.h"
 #include "OpenGl/Shader.h"
-#include "OpenGl/VertexArray.h"
 #include "OpenGl/Texture.h"
 #include <glm/glm.hpp>
 #include <assimp/scene.h>
@@ -12,39 +12,6 @@
 #define MAX_BONE_INFLUENCE 4
 
 namespace Agate {
-    struct Vertex {
-        // position
-        glm::vec3 Position;
-        // normal
-        glm::vec3 Normal;
-        // texCoords
-        glm::vec2 TexCoords;
-        // tangent
-        glm::vec3 Tangent;
-        // bitangent
-        glm::vec3 Bitangent;
-    };
-
-    class Mesh {
-    public:
-        // mesh data
-        std::vector<Vertex> vertices;
-        std::vector<unsigned int> indices;
-        std::vector<Texture> textures;
-
-        Mesh(std::vector<Vertex> vertices, std::vector<unsigned int> indices, std::vector<Texture> textures);
-
-
-        void Draw(Shader &shader);
-
-        virtual ~Mesh();
-
-    private:
-        //  render data
-        std::shared_ptr<VertexArray> VA;
-
-        void setupMesh();
-    };
 
     class ModelLoader {
     public:

--- a/Agate/src/Agate/Rendering/ModelLoader.h
+++ b/Agate/src/Agate/Rendering/ModelLoader.h
@@ -93,11 +93,6 @@ protected:
          */
         std::future<bool> m_futureScene;
 
-        /**
-         * @brief Flag to determine if a load has been started
-         */
-        bool m_startedLoad = false;
-
     private:
 
         //helper function

--- a/Agate/src/Agate/Rendering/ModelLoader.h
+++ b/Agate/src/Agate/Rendering/ModelLoader.h
@@ -20,6 +20,11 @@ namespace Agate {
         std::string m_path;
 
         /**
+         * @brief Destructor - Blocks and waits for future completion if necessary
+         */
+        virtual ~ModelLoader();
+
+        /**
         * @brief Render the model; finalize loading when the async import completes.
         *
         * Each frame, this function polls the async import future. When the import
@@ -87,6 +92,11 @@ protected:
          *        access to the result of the asynchronous load task
          */
         std::future<bool> m_futureScene;
+
+        /**
+         * @brief Flag to determine if a load has been started
+         */
+        bool m_startedLoad = false;
 
     private:
 

--- a/Agate/src/Agate/Rendering/ModelLoader.h
+++ b/Agate/src/Agate/Rendering/ModelLoader.h
@@ -7,7 +7,6 @@
 #include <glm/glm.hpp>
 #include <assimp/Importer.hpp>
 #include <assimp/scene.h>
-#include <assimp/postprocess.h>
 #include <future>
 
 #define MAX_BONE_INFLUENCE 4
@@ -94,13 +93,6 @@ namespace Agate {
         std::future<const aiScene*> m_futureScene;
 
     private:
-        /**
-        * @brief Build the Assimp post-processing flags for import.
-        *
-        * @param flipUVs If true, include aiProcess_FlipUVs.
-        * @return Bitmask of Assimp aiProcess_* flags passed to ReadFile().
-        */
-        unsigned int getAssimpFlags(bool flipUVs = false);
 
         /**
         * @brief Convert a loaded Assimp scene into engine-ready mesh data.

--- a/Agate/src/Agate/Rendering/ModelLoader.h
+++ b/Agate/src/Agate/Rendering/ModelLoader.h
@@ -68,20 +68,6 @@ namespace Agate {
 
     private:
 
-        /**
-        * @brief Convert a loaded Assimp scene into engine-ready mesh data.
-        *
-        * Validates the imported scene and recursively processes the node hierarchy to
-        * populate this loader's mesh list.
-        *
-        * @param scene Scene produced by Assimp::Importer::ReadFile().
-        *
-        * @warning Potentially expensive: performs vertex/index extraction and may
-        *          trigger GPU buffer uploads depending on your Mesh implementation.
-        *          Intended to be called once, after the async import completes.
-        */
-        void prepareScene(const aiScene *scene);
-
         //helper function
         std::string extractDirectory(const std::string& path);
     };

--- a/Agate/src/Agate/Rendering/ModelLoader.h
+++ b/Agate/src/Agate/Rendering/ModelLoader.h
@@ -88,8 +88,17 @@ namespace Agate {
 
 
     private:
-        // this future is used to load the model independent of the main thread
+        
+        /**
+         * @brief The AssimpLoader is kept as a class member in order to preserve the
+         *        lifetimes of objects managed by assimp
+         */
         AssimpLoader assimp;
+
+        /**
+         * @brief A future for the loaded model is kept as a class member to preserve
+         *        access to the result of the asynchronous load task
+         */
         std::future<const aiScene*> m_futureScene;
 
     private:

--- a/Agate/src/Agate/Rendering/ModelLoader.h
+++ b/Agate/src/Agate/Rendering/ModelLoader.h
@@ -1,7 +1,6 @@
 #ifndef AGATE_MODELLOADER_H
 #define AGATE_MODELLOADER_H
 
-#include "AssimpLoader.h"
 #include "Mesh.h"
 #include "OpenGl/Shader.h"
 #include "OpenGl/Texture.h"
@@ -27,13 +26,11 @@ namespace Agate {
          * can continue without blocking.
          *
          * @param path     Filesystem path to the model file.
-         * @param gamma    Enable/disable gamma correction for textures.
-         * @param flipUVs  If true, flip UV coordinates vertically during import.
          *
          * @note The actual GPU/engine-side preparation is deferred until Draw() observes
          *       the future is ready and calls prepareScene().
          */ 
-        ModelLoader(std::string const &path, bool flipUVs = false);
+        ModelLoader(std::string const &path);
 
         /**
         * @brief Render the model; finalize loading when the async import completes.
@@ -47,16 +44,42 @@ namespace Agate {
         *
         * @note Non-blocking: if the import is not ready yet, this function only draws
         *       meshes that have already been prepared (often none).
+        * 
+        * @warning If `ModelLoader::LoadModel` has not been invoked, this method will
+        *          never do anything
         */
         void Draw(Shader &shader);
 
-    private:
-        
         /**
-         * @brief The AssimpLoader is kept as a class member in order to preserve the
-         *        lifetimes of objects managed by assimp
+         * @brief Instructs the loader to start internally loading its model
+         * 
+         * @note Must be called in order for `ModelLoader::Draw` to ever do anything
          */
-        AssimpLoader assimp;
+        void LoadModel();
+
+protected:
+
+        /**
+         * @brief Starts loading the model this loader was given
+         * 
+         * @return Future that becomes valid upon completion of loading the model
+         *         and indicates operation status
+         * @retval true Success
+         * @retval false Error
+         * 
+         * @note Implementations are encouraged to define this in a non-blocking
+         *       manner
+         */
+        virtual std::future<bool> loadModel() = 0;
+
+        /**
+         * @brief Parses the loaded model into a form that the engine can render
+         * 
+         * @return Parsed meshes
+         */
+        virtual std::vector<Mesh> parseModel() = 0;
+
+    private:
 
         /**
          * @brief A future for the loaded model is kept as a class member to preserve

--- a/Agate/src/Agate/Rendering/ModelLoader.h
+++ b/Agate/src/Agate/Rendering/ModelLoader.h
@@ -5,6 +5,7 @@
 #include "OpenGl/Shader.h"
 #include "OpenGl/Texture.h"
 #include <future>
+#include <memory>
 
 #define MAX_BONE_INFLUENCE 4
 
@@ -17,20 +18,6 @@ namespace Agate {
         std::vector<Mesh> m_meshes;
         std::string m_directory;
         std::string m_path;
-
-        /**
-         * @brief Construct a ModelLoader and start loading a model on a background task.
-         *
-         * Initializes model metadata and launches an asynchronous Assimp import using
-         * std::async. The returned aiScene* is stored in a std::future so the caller
-         * can continue without blocking.
-         *
-         * @param path     Filesystem path to the model file.
-         *
-         * @note The actual GPU/engine-side preparation is deferred until Draw() observes
-         *       the future is ready and calls prepareScene().
-         */ 
-        ModelLoader(std::string const &path);
 
         /**
         * @brief Render the model; finalize loading when the async import completes.
@@ -53,11 +40,25 @@ namespace Agate {
         /**
          * @brief Instructs the loader to start internally loading its model
          * 
-         * @note Must be called in order for `ModelLoader::Draw` to ever do anything
+         * @param path Path to the model file
          */
-        void LoadModel();
+        static std::unique_ptr<ModelLoader> LoadModel(std::string const &path);
 
 protected:
+
+        /**
+         * @brief Construct a ModelLoader and start loading a model on a background task.
+         *
+         * Initializes model metadata and launches an asynchronous Assimp import using
+         * std::async. The returned aiScene* is stored in a std::future so the caller
+         * can continue without blocking.
+         *
+         * @param path     Filesystem path to the model file.
+         *
+         * @note The actual GPU/engine-side preparation is deferred until Draw() observes
+         *       the future is ready and calls prepareScene().
+         */ 
+        ModelLoader(std::string const &path);
 
         /**
          * @brief Starts loading the model this loader was given

--- a/Agate/src/Agate/Rendering/ModelLoader.h
+++ b/Agate/src/Agate/Rendering/ModelLoader.h
@@ -14,7 +14,7 @@ namespace Agate {
     class ModelLoader {
     public:
         // model data
-        std::vector<Texture> textures_loaded;    // stores all the textures loaded so far, optimization to make sure textures aren't loaded more than once.
+        std::vector<Texture> m_texturesLoaded;    // stores all the textures loaded so far, optimization to make sure textures aren't loaded more than once.
         std::vector<Mesh> m_meshes;
         std::string m_directory;
         std::string m_path;

--- a/Agate/src/Agate/Rendering/ModelLoader.h
+++ b/Agate/src/Agate/Rendering/ModelLoader.h
@@ -52,7 +52,6 @@ namespace Agate {
         */
         void Draw(Shader &shader);
 
-
     private:
         
         /**
@@ -85,8 +84,6 @@ namespace Agate {
 
         // processes a node in a recursive fashion. Processes each individual mesh located at the node and repeats this process on its children nodes (if any).
         void processNode(aiNode *node, const aiScene *scene, const glm::mat4 &parentTransform);
-
-        Mesh processMesh(aiMesh *mesh, const aiScene *scene, const glm::mat4 &transform);
 
         //helper function
         std::string extractDirectory(const std::string& path);

--- a/Agate/src/Agate/Rendering/ModelLoader.h
+++ b/Agate/src/Agate/Rendering/ModelLoader.h
@@ -82,9 +82,6 @@ namespace Agate {
         */
         void prepareScene(const aiScene *scene);
 
-        // processes a node in a recursive fashion. Processes each individual mesh located at the node and repeats this process on its children nodes (if any).
-        void processNode(aiNode *node, const aiScene *scene, const glm::mat4 &parentTransform);
-
         //helper function
         std::string extractDirectory(const std::string& path);
     };

--- a/Agate/src/Agate/Rendering/ModelLoader.h
+++ b/Agate/src/Agate/Rendering/ModelLoader.h
@@ -5,8 +5,6 @@
 #include "Mesh.h"
 #include "OpenGl/Shader.h"
 #include "OpenGl/Texture.h"
-#include <glm/glm.hpp>
-#include <assimp/scene.h>
 #include <future>
 
 #define MAX_BONE_INFLUENCE 4
@@ -64,7 +62,7 @@ namespace Agate {
          * @brief A future for the loaded model is kept as a class member to preserve
          *        access to the result of the asynchronous load task
          */
-        std::future<const aiScene*> m_futureScene;
+        std::future<bool> m_futureScene;
 
     private:
 

--- a/Agate/src/Agate/Rendering/ModelLoader.h
+++ b/Agate/src/Agate/Rendering/ModelLoader.h
@@ -123,10 +123,6 @@ namespace Agate {
 
         //helper function
         std::string extractDirectory(const std::string& path);
-
-        // checks all material textures of a given type and loads the textures if they're not loaded yet.
-        // the required info is returned as a Texture struct.
-        std::vector<Texture> loadMaterialTextures(aiMaterial *mat, aiTextureType type, std::string typeName);
     };
 }
 

--- a/Application/src/Application.cpp
+++ b/Application/src/Application.cpp
@@ -39,7 +39,8 @@ public:
         camera = new Agate::Camera(*shader);
         camera->setCameraPos({1.0f,1.0f,20.0f});
         camera->setCameraSpeed(10.f);
-        model = new Agate::ModelLoader(std::filesystem::path("Shaders/vokselia_spawn/vokselia_spawn.obj").generic_string());
+        model = new Agate::AssimpLoader(std::filesystem::path("Shaders/vokselia_spawn/vokselia_spawn.obj").generic_string());
+        model->LoadModel();
     }
 
     void Detach() override

--- a/Application/src/Application.cpp
+++ b/Application/src/Application.cpp
@@ -39,8 +39,7 @@ public:
         camera = new Agate::Camera(*shader);
         camera->setCameraPos({1.0f,1.0f,20.0f});
         camera->setCameraSpeed(10.f);
-        model = new Agate::AssimpLoader(std::filesystem::path("Shaders/vokselia_spawn/vokselia_spawn.obj").generic_string());
-        model->LoadModel();
+        model = Agate::ModelLoader::LoadModel(std::filesystem::path("Shaders/vokselia_spawn/vokselia_spawn.obj").generic_string()).release();
     }
 
     void Detach() override


### PR DESCRIPTION
This PR introduces a new class `AssimpLoader` and refactor of `ModelLoader` that decouples the `ModelLoader` class from the "assimp" asset importer library. A summary of the changes is as follows:

- Extract all assimp logic from `ModelLoader` to new child class `AssimpLoader`
- Modify public interface of `ModelLoader` to only expose `ModelLoader::Draw` and `ModelLoader::LoadModel`
- Extract class `Mesh` and supporting struct `Vector` to `Mesh.h`/`Mesh.cpp`

Resolves #48 