### PR TITLE
Add ModelEditor

### DIFF
--- a/Agate/src/Agate/Rendering/AssimpLoader.cpp
+++ b/Agate/src/Agate/Rendering/AssimpLoader.cpp
@@ -26,24 +26,18 @@ inline glm::mat4 convertMatrix(const aiMatrix4x4& matrix) {
 
 namespace Agate {
 
-AssimpLoader::AssimpLoader(std::string path, bool flipUVs):
+AssimpLoader::AssimpLoader(const std::string& path, bool flipUVs):
         ModelLoader(path), m_flipUVs(flipUVs), m_scene(nullptr) {}
 
-std::future<bool> AssimpLoader::loadModel() {
+AssimpLoader::~AssimpLoader() = default;
+
+void AssimpLoader::loadModel() {
 
     unsigned int flags = getFlags();
-
-    return std::async(std::launch::async, [this, flags]() {
-
-        this->m_scene = m_importer.ReadFile(this->m_path, flags);
-
-        if (!m_scene || m_scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE || !m_scene->mRootNode) {
-            PRINTERROR("ASSIMP ERROR: {}", m_importer.GetErrorString());
-            return false;
-        }
-
-        return true;
-    });
+    this->m_scene = m_importer.ReadFile(this->m_path, flags);
+    if (!m_scene || m_scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE || !m_scene->mRootNode) {
+        PRINTERROR("ASSIMP ERROR: {}", m_importer.GetErrorString());
+    }
 }
 
 std::vector<Mesh> AssimpLoader::parseModel() {

--- a/Agate/src/Agate/Rendering/AssimpLoader.cpp
+++ b/Agate/src/Agate/Rendering/AssimpLoader.cpp
@@ -31,13 +31,17 @@ AssimpLoader::AssimpLoader(const std::string& path, bool flipUVs):
 
 AssimpLoader::~AssimpLoader() = default;
 
-void AssimpLoader::loadModel() {
+bool AssimpLoader::loadModel() {
 
     unsigned int flags = getFlags();
     this->m_scene = m_importer.ReadFile(this->m_path, flags);
     if (!m_scene || m_scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE || !m_scene->mRootNode) {
         PRINTERROR("ASSIMP ERROR: {}", m_importer.GetErrorString());
+
+        return false;
     }
+
+    return true;
 }
 
 std::vector<Mesh> AssimpLoader::parseModel() {

--- a/Agate/src/Agate/Rendering/AssimpLoader.h
+++ b/Agate/src/Agate/Rendering/AssimpLoader.h
@@ -41,17 +41,13 @@ public:
 protected:
 
     /**
-     * @brief Starts loading the model this loader was given
+     * @brief Performs the I/O part of loading the model
      * 
-     * @return Future that becomes valid upon completion of loading the model
-     *         and indicates operation status
+     * @return Operation status
      * @retval true Success
-     * @retval false Error
-     * 
-     * @note Implementations are encouraged to define this in a non-blocking
-     *       manner
+     * @retval false Failure
      */
-    virtual void loadModel() final override;
+    virtual bool loadModel() final override;
 
     /**
      * @brief Parses the loaded model into a form that the engine can render

--- a/Agate/src/Agate/Rendering/AssimpLoader.h
+++ b/Agate/src/Agate/Rendering/AssimpLoader.h
@@ -34,7 +34,9 @@ public:
      * @param flipUVs If true, include aiProcess_FlipUVs for postprocessing.
      *                Default false
      */
-    AssimpLoader(std::string path, bool flipUVs = false);
+    AssimpLoader(const std::string& path, bool flipUVs = false);
+
+    virtual ~AssimpLoader() override;
 
 protected:
 
@@ -49,7 +51,7 @@ protected:
      * @note Implementations are encouraged to define this in a non-blocking
      *       manner
      */
-    virtual std::future<bool> loadModel() final override;
+    virtual void loadModel() final override;
 
     /**
      * @brief Parses the loaded model into a form that the engine can render

--- a/Agate/src/Agate/Rendering/Mesh.cpp
+++ b/Agate/src/Agate/Rendering/Mesh.cpp
@@ -8,8 +8,6 @@ Mesh::Mesh(std::vector<Vertex> vertices, std::vector<unsigned int> indices, std:
     this->m_vertices = std::move(vertices);
     this->m_indices = std::move(indices);
     this->m_textures = std::move(textures);
-
-    setupMesh();
 }
 
 //@todo we should not really render here

--- a/Agate/src/Agate/Rendering/Mesh.h
+++ b/Agate/src/Agate/Rendering/Mesh.h
@@ -54,11 +54,13 @@ public:
 
     virtual ~Mesh();
 
+    void setupMesh();
+
 private:
     //  render data
     std::shared_ptr<VertexArray> m_VA;
 
-    void setupMesh();
+
 };
 
 }

--- a/Agate/src/Agate/Rendering/ModelEditor.cpp
+++ b/Agate/src/Agate/Rendering/ModelEditor.cpp
@@ -42,4 +42,23 @@ void ModelEditor::SetScale(const glm::vec3& scalar) {
     m_transform.scale = scalar;
 }
 
+glm::mat4 ModelEditor::ModelMatrix() {
+
+    const glm::mat4 translation{
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        m_transform.position.x, m_transform.position.y, m_transform.position.z, 1
+    };
+    const glm::mat4 scale{
+        m_transform.scale.x, 0, 0, 0,
+        0, m_transform.scale.y, 0, 0,
+        0, 0, m_transform.scale.z, 0,
+        0, 0, 0, 1
+    };
+    const glm::mat4 rotation = glm::mat4_cast(m_transform.rotation);
+
+    return translation * rotation * scale;
+}
+
 } // namespace Agate

--- a/Agate/src/Agate/Rendering/ModelEditor.cpp
+++ b/Agate/src/Agate/Rendering/ModelEditor.cpp
@@ -34,13 +34,12 @@ void ModelEditor::SetPosition(const glm::vec3& position) {
     m_transform.position = position;
 }
 
-void ModelEditor::Scale(glm::vec3 scalar) {
-    PRINTWARN("Scale() Not Yet Implemented");
+void ModelEditor::Scale(const glm::vec3& scalar) {
+    m_transform.scale *= scalar;
 }
 
-void ModelEditor::SetScale(glm::vec3 scalar) {
-    PRINTWARN("SetScale() Not Yet Implemented");
+void ModelEditor::SetScale(const glm::vec3& scalar) {
+    m_transform.scale = scalar;
 }
-
 
 } // namespace Agate

--- a/Agate/src/Agate/Rendering/ModelEditor.cpp
+++ b/Agate/src/Agate/Rendering/ModelEditor.cpp
@@ -65,4 +65,20 @@ glm::vec3 ModelEditor::EulerAngles() const {
     return glm::eulerAngles(m_transform.rotation);
 }
 
+void ModelEditor::LoadTextures() {
+
+    /*
+        This seems to block for quite a while after the model
+        loads, but I think a fix should be deferred until this
+        is running on the render thread
+    */
+    PRINTMSG("Loading textures - This may take a minute");
+    for (auto& mesh: m_meshes) {
+        for (auto& texture: mesh.m_textures) {
+            texture.initialize();
+        }
+        mesh.setupMesh();
+    }
+}
+
 } // namespace Agate

--- a/Agate/src/Agate/Rendering/ModelEditor.cpp
+++ b/Agate/src/Agate/Rendering/ModelEditor.cpp
@@ -1,0 +1,15 @@
+#include "ModelEditor.h"
+
+namespace Agate {
+
+ModelEditor::ModelEditor(std::string path, std::vector<Mesh> meshes)
+    : m_path(path), m_meshes(meshes) {}
+
+void ModelEditor::Draw(Shader& shader) {
+
+    for (Mesh& mesh: m_meshes) {
+        mesh.Draw(shader);
+    }
+}
+
+} // namespace Agate

--- a/Agate/src/Agate/Rendering/ModelEditor.cpp
+++ b/Agate/src/Agate/Rendering/ModelEditor.cpp
@@ -44,21 +44,11 @@ void ModelEditor::SetScale(const glm::vec3& scalar) {
 
 glm::mat4 ModelEditor::ModelMatrix() const {
 
-    const glm::mat4 translation{
-        1, 0, 0, 0,
-        0, 1, 0, 0,
-        0, 0, 1, 0,
-        m_transform.position.x, m_transform.position.y, m_transform.position.z, 1
-    };
-    const glm::mat4 scale{
-        m_transform.scale.x, 0, 0, 0,
-        0, m_transform.scale.y, 0, 0,
-        0, 0, m_transform.scale.z, 0,
-        0, 0, 0, 1
-    };
-    const glm::mat4 rotation = glm::mat4_cast(m_transform.rotation);
+    glm::mat4 model{ 1.0f };
+    const glm::mat4 translation = glm::translate(model, m_transform.position);
+    model = model * glm::mat4_cast(m_transform.rotation);
 
-    return translation * rotation * scale;
+    return glm::scale(model, m_transform.scale);
 }
 
 glm::vec3 ModelEditor::EulerAngles() const {

--- a/Agate/src/Agate/Rendering/ModelEditor.cpp
+++ b/Agate/src/Agate/Rendering/ModelEditor.cpp
@@ -18,20 +18,20 @@ void ModelEditor::Draw(Shader& shader) {
     }
 }
 
-void ModelEditor::Rotate(glm::f32 radians, glm::vec3 axis) {
+void ModelEditor::Rotate(glm::f32 radians, const glm::vec3& axis) {
     m_transform.rotation = glm::angleAxis(radians, axis) * m_transform.rotation;
 }
 
-void ModelEditor::SetRotation(glm::f32 radians, glm::vec3 axis) {
+void ModelEditor::SetRotation(glm::f32 radians, const glm::vec3& axis) {
     m_transform.rotation = glm::angleAxis(radians, axis);
 }
 
-void ModelEditor::Translate(glm::vec3 translation) {
-    PRINTWARN("Translate() Not Yet Implemented");
+void ModelEditor::Translate(const glm::vec3& translation) {
+    m_transform.position += translation;
 }
 
-void ModelEditor::SetPosition(glm::vec3 position) {
-    PRINTWARN("SetPosition() Not Yet Implemented");
+void ModelEditor::SetPosition(const glm::vec3& position) {
+    m_transform.position = position;
 }
 
 void ModelEditor::Scale(glm::vec3 scalar) {

--- a/Agate/src/Agate/Rendering/ModelEditor.cpp
+++ b/Agate/src/Agate/Rendering/ModelEditor.cpp
@@ -18,12 +18,12 @@ void ModelEditor::Draw(Shader& shader) {
     }
 }
 
-void ModelEditor::Rotate(double radians, glm::vec3 axis) {
-    PRINTWARN("Rotate() Not Yet Implemented");
+void ModelEditor::Rotate(glm::f32 radians, glm::vec3 axis) {
+    m_transform.rotation = glm::angleAxis(radians, axis) * m_transform.rotation;
 }
 
-void ModelEditor::SetRotation(double radians, glm::vec3 axis) {
-    PRINTWARN("SetRotation() Not Yet Implemented");
+void ModelEditor::SetRotation(glm::f32 radians, glm::vec3 axis) {
+    m_transform.rotation = glm::angleAxis(radians, axis);
 }
 
 void ModelEditor::Translate(glm::vec3 translation) {

--- a/Agate/src/Agate/Rendering/ModelEditor.cpp
+++ b/Agate/src/Agate/Rendering/ModelEditor.cpp
@@ -18,4 +18,29 @@ void ModelEditor::Draw(Shader& shader) {
     }
 }
 
+void ModelEditor::Rotate(double radians, glm::vec3 axis) {
+    PRINTWARN("Rotate() Not Yet Implemented");
+}
+
+void ModelEditor::SetRotation(double radians, glm::vec3 axis) {
+    PRINTWARN("SetRotation() Not Yet Implemented");
+}
+
+void ModelEditor::Translate(glm::vec3 translation) {
+    PRINTWARN("Translate() Not Yet Implemented");
+}
+
+void ModelEditor::SetPosition(glm::vec3 position) {
+    PRINTWARN("SetPosition() Not Yet Implemented");
+}
+
+void ModelEditor::Scale(glm::vec3 scalar) {
+    PRINTWARN("Scale() Not Yet Implemented");
+}
+
+void ModelEditor::SetScale(glm::vec3 scalar) {
+    PRINTWARN("SetScale() Not Yet Implemented");
+}
+
+
 } // namespace Agate

--- a/Agate/src/Agate/Rendering/ModelEditor.cpp
+++ b/Agate/src/Agate/Rendering/ModelEditor.cpp
@@ -1,9 +1,15 @@
 #include "ModelEditor.h"
+#include <glm/glm.hpp>
 
 namespace Agate {
 
+Transform::Transform()
+        : position(glm::vec3(0, 0, 0)),
+          scale(glm::vec3(1, 1, 1)),
+          rotation(glm::quat(0, 1, 0, 0))  {}
+
 ModelEditor::ModelEditor(std::string path, std::vector<Mesh> meshes)
-    : m_path(path), m_meshes(meshes) {}
+        : m_path(path), m_meshes(meshes) {}
 
 void ModelEditor::Draw(Shader& shader) {
 

--- a/Agate/src/Agate/Rendering/ModelEditor.cpp
+++ b/Agate/src/Agate/Rendering/ModelEditor.cpp
@@ -42,7 +42,7 @@ void ModelEditor::SetScale(const glm::vec3& scalar) {
     m_transform.scale = scalar;
 }
 
-glm::mat4 ModelEditor::ModelMatrix() {
+glm::mat4 ModelEditor::ModelMatrix() const {
 
     const glm::mat4 translation{
         1, 0, 0, 0,
@@ -59,6 +59,10 @@ glm::mat4 ModelEditor::ModelMatrix() {
     const glm::mat4 rotation = glm::mat4_cast(m_transform.rotation);
 
     return translation * rotation * scale;
+}
+
+glm::vec3 ModelEditor::EulerAngles() const {
+    return glm::eulerAngles(m_transform.rotation);
 }
 
 } // namespace Agate

--- a/Agate/src/Agate/Rendering/ModelEditor.cpp
+++ b/Agate/src/Agate/Rendering/ModelEditor.cpp
@@ -6,7 +6,7 @@ namespace Agate {
 Transform::Transform()
         : position(glm::vec3(0, 0, 0)),
           scale(glm::vec3(1, 1, 1)),
-          rotation(glm::quat(0, 1, 0, 0))  {}
+          rotation(glm::quat(1, 0, 0, 0))  {}
 
 ModelEditor::ModelEditor(std::string path, std::vector<Mesh> meshes)
         : m_path(path), m_meshes(meshes) {}

--- a/Agate/src/Agate/Rendering/ModelEditor.h
+++ b/Agate/src/Agate/Rendering/ModelEditor.h
@@ -12,13 +12,22 @@
 #include "OpenGl/Shader.h"
 #include <string>
 #include <vector>
+#include <glm/glm.hpp>
 
 namespace Agate {
+
+struct Transform {
+    Transform();
+    glm::vec3 position;
+    glm::vec3 scale;
+    glm::quat rotation;
+};
 
 class ModelEditor {
 private:
     std::string m_path;
     std::vector<Mesh> m_meshes;
+    Transform m_transform;
 public:
 
     /**

--- a/Agate/src/Agate/Rendering/ModelEditor.h
+++ b/Agate/src/Agate/Rendering/ModelEditor.h
@@ -56,7 +56,7 @@ public:
      * @param radians Amount to rotate by, in radians
      * @param axis Normalized vector along the axis to rotate about
      */
-    void Rotate(glm::f32 radians, glm::vec3 axis);
+    void Rotate(glm::f32 radians, const glm::vec3& axis);
 
     /**
      * @brief Sets the models rotation, ignoring current rotation
@@ -64,14 +64,14 @@ public:
      * @param radians Amount model should be rotated, in radians
      * @param axis Normalized vector along the axis to rotate about
      */
-    void SetRotation(glm::f32 radians, glm::vec3 axis);
+    void SetRotation(glm::f32 radians, const glm::vec3& axis);
 
     /**
      * @brief Moves the position of the model
      * 
      * @param translation Vector to add to the model's current position
      */
-    void Translate(glm::vec3 translation);
+    void Translate(const glm::vec3& translation);
 
     /**
      * @brief Sets the position of the model relative to its local
@@ -79,7 +79,7 @@ public:
      * 
      * @param position Position vector for the model
      */
-    void SetPosition(glm::vec3 position);
+    void SetPosition(const glm::vec3& position);
 
     /**
      * @brief Resizes the model by a scalar vector

--- a/Agate/src/Agate/Rendering/ModelEditor.h
+++ b/Agate/src/Agate/Rendering/ModelEditor.h
@@ -56,7 +56,7 @@ public:
      * @param radians Amount to rotate by, in radians
      * @param axis Normalized vector along the axis to rotate about
      */
-    void Rotate(double radians, glm::vec3 axis);
+    void Rotate(glm::f32 radians, glm::vec3 axis);
 
     /**
      * @brief Sets the models rotation, ignoring current rotation
@@ -64,7 +64,7 @@ public:
      * @param radians Amount model should be rotated, in radians
      * @param axis Normalized vector along the axis to rotate about
      */
-    void SetRotation(double radians, glm::vec3 axis);
+    void SetRotation(glm::f32 radians, glm::vec3 axis);
 
     /**
      * @brief Moves the position of the model

--- a/Agate/src/Agate/Rendering/ModelEditor.h
+++ b/Agate/src/Agate/Rendering/ModelEditor.h
@@ -118,6 +118,11 @@ public:
      * @return Vector with rotations about the X, Y, and Z axes
      */
     glm::vec3 EulerAngles() const;
+
+    /**
+     * @brief Loads this model's textures into the OpenGL context
+     */
+    void LoadTextures();
 };
 } // namespace Agate
 

--- a/Agate/src/Agate/Rendering/ModelEditor.h
+++ b/Agate/src/Agate/Rendering/ModelEditor.h
@@ -49,6 +49,51 @@ public:
      * @param shader Shader to use when drawing
      */
     void Draw(Shader& shader);
+
+    /**
+     * @brief Rotates the model about an axis
+     * 
+     * @param radians Amount to rotate by, in radians
+     * @param axis Normalized vector along the axis to rotate about
+     */
+    void Rotate(double radians, glm::vec3 axis);
+
+    /**
+     * @brief Sets the models rotation, ignoring current rotation
+     * 
+     * @param radians Amount model should be rotated, in radians
+     * @param axis Normalized vector along the axis to rotate about
+     */
+    void SetRotation(double radians, glm::vec3 axis);
+
+    /**
+     * @brief Moves the position of the model
+     * 
+     * @param translation Vector to add to the model's current position
+     */
+    void Translate(glm::vec3 translation);
+
+    /**
+     * @brief Sets the position of the model relative to its local
+     *        origin
+     * 
+     * @param position Position vector for the model
+     */
+    void SetPosition(glm::vec3 position);
+
+    /**
+     * @brief Resizes the model by a scalar vector
+     * 
+     * @param scalar Scalar vector with a multiplier for each axis
+     */
+    void Scale(glm::vec3 scalar);
+
+    /**
+     * @brief Sets the model's size to a scalar of its original size
+     * 
+     * @param scalar Scalar vector with a multiplier for each axis
+     */
+    void SetScale(glm::vec3 scalar);
 };
 } // namespace Agate
 

--- a/Agate/src/Agate/Rendering/ModelEditor.h
+++ b/Agate/src/Agate/Rendering/ModelEditor.h
@@ -16,6 +16,10 @@
 
 namespace Agate {
 
+/**
+ * @brief Plain data struct with transformation data used to
+ *        create a model matrix
+ */
 struct Transform {
     Transform();
     glm::vec3 position;
@@ -23,6 +27,10 @@ struct Transform {
     glm::quat rotation;
 };
 
+/**
+ * @brief Wraps a renderable model and provides mutators to
+ *        edit the transformation of the model
+ */
 class ModelEditor {
 private:
     std::string m_path;

--- a/Agate/src/Agate/Rendering/ModelEditor.h
+++ b/Agate/src/Agate/Rendering/ModelEditor.h
@@ -86,14 +86,14 @@ public:
      * 
      * @param scalar Scalar vector with a multiplier for each axis
      */
-    void Scale(glm::vec3 scalar);
+    void Scale(const glm::vec3& scalar);
 
     /**
      * @brief Sets the model's size to a scalar of its original size
      * 
      * @param scalar Scalar vector with a multiplier for each axis
      */
-    void SetScale(glm::vec3 scalar);
+    void SetScale(const glm::vec3& scalar);
 };
 } // namespace Agate
 

--- a/Agate/src/Agate/Rendering/ModelEditor.h
+++ b/Agate/src/Agate/Rendering/ModelEditor.h
@@ -106,8 +106,18 @@ public:
      * 
      * @note The model matrix is fully computed from the transform every
      *       time this method is called
+     * 
+     * @return 4x4 model matrix for this model
      */
-    glm::mat4 ModelMatrix();
+    glm::mat4 ModelMatrix() const;
+
+    /**
+     * @brief Rotation of the model as 3 angles corresponding to rotations
+     *        about the X, Y, and Z axes respectively
+     * 
+     * @return Vector with rotations about the X, Y, and Z axes
+     */
+    glm::vec3 EulerAngles() const;
 };
 } // namespace Agate
 

--- a/Agate/src/Agate/Rendering/ModelEditor.h
+++ b/Agate/src/Agate/Rendering/ModelEditor.h
@@ -1,0 +1,41 @@
+/**
+ * @brief Include file for the ModelEditor class
+ * 
+ * Handles internal model representation and allows editing of
+ * the base model in the editor (before sending to the renderer)
+ */
+
+#ifndef AGATE_MODELEDITOR_H
+#define AGATE_MODELEDITOR_H
+
+#include "Mesh.h"
+#include "OpenGl/Shader.h"
+#include <string>
+#include <vector>
+
+namespace Agate {
+
+class ModelEditor {
+private:
+    std::string m_path;
+    std::vector<Mesh> m_meshes;
+public:
+
+    /**
+     * @brief Constructor - initializes with given meshes and path
+     * 
+     * @param path Path to the source file of this model
+     * @param meshes Mesh data for this model
+     */
+    ModelEditor(std::string path, std::vector<Mesh> meshes);
+
+    /**
+     * @brief Draws the underlying model
+     * 
+     * @param shader Shader to use when drawing
+     */
+    void Draw(Shader& shader);
+};
+} // namespace Agate
+
+#endif // AGATE_MODELEDITOR_H

--- a/Agate/src/Agate/Rendering/ModelEditor.h
+++ b/Agate/src/Agate/Rendering/ModelEditor.h
@@ -94,6 +94,20 @@ public:
      * @param scalar Scalar vector with a multiplier for each axis
      */
     void SetScale(const glm::vec3& scalar);
+
+    /**
+     * @brief Computes the model matrix for this model using its current
+     *        transform
+     * 
+     * The model matrix is the third component of the model-view-projection
+     * rendering model and is used to convert a point from its local position
+     * to its world position as defined by a translation, rotation, and
+     * rescale.
+     * 
+     * @note The model matrix is fully computed from the transform every
+     *       time this method is called
+     */
+    glm::mat4 ModelMatrix();
 };
 } // namespace Agate
 

--- a/Agate/src/Agate/Rendering/ModelEditor.h
+++ b/Agate/src/Agate/Rendering/ModelEditor.h
@@ -22,6 +22,11 @@ private:
 public:
 
     /**
+     * @brief Default constructor
+     */
+    ModelEditor() = default;
+
+    /**
      * @brief Constructor - initializes with given meshes and path
      * 
      * @param path Path to the source file of this model

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -39,12 +39,24 @@ void Agate::ModelLoader::Draw(Agate::Shader &shader) {
     m_model.Draw(shader);
 }
 
-std::unique_ptr<Agate::ModelLoader> Agate::ModelLoader::LoadModel(const std::string &path) {
+std::future<std::unique_ptr<Agate::ModelLoader>> Agate::ModelLoader::LoadModel(const std::string &path) {
 
-    std::unique_ptr<Agate::ModelLoader> loader = std::make_unique<AssimpLoader>(path);
-    loader->m_futureScene = loader->loadModel();
+    return std::async(std::launch::async, [path]() {
 
-    return loader;
+        std::unique_ptr<Agate::ModelLoader> loader = std::make_unique<AssimpLoader>(path);
+        loader->m_futureScene = loader->loadModel();
+
+        loader->m_futureScene.wait();
+        if (loader->m_futureScene.get()) {
+            loader->m_meshes = loader->parseModel();
+            loader->m_model = Agate::ModelEditor(loader->m_path, loader->m_meshes);
+        } else {
+            PRINTWARN("ModelLoader: Model load failed");
+        }
+
+        return loader;
+    });
+
 }
 
 std::string Agate::ModelLoader::extractDirectory(const std::string &path) {

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -8,34 +8,12 @@
 
 namespace fs = std::filesystem;
 
-Agate::ModelLoader::~ModelLoader() {
-
-    // Block until asynchronous load is finished, if applicable
-    if (m_futureScene.valid()) {
-        m_futureScene.wait();
-    }
-}
+Agate::ModelLoader::~ModelLoader() = default;
 
 Agate::ModelLoader::ModelLoader(std::string const &path)
     : m_directory(extractDirectory(path)), m_path(path) {}
 
 void Agate::ModelLoader::Draw(Agate::Shader &shader) {
-
-    // Once we get the scene we prepare it, i.e once we get the futures value we use it 
-    // once used it is no longer valid i.e this if is skipped
-    if (m_futureScene.valid()) {
-        auto status = m_futureScene.wait_for(std::chrono::seconds(0));
-        if (status == std::future_status::ready) {
-            // Once this is done the future scene will no longer be valid
-            if (m_futureScene.get()) {
-                m_meshes = parseModel();
-                m_model = Agate::ModelEditor(m_path, m_meshes);
-            } else {
-                PRINTWARN("ModelLoader: Model load failed");
-            }
-        }
-    }
-
     m_model.Draw(shader);
 }
 
@@ -44,19 +22,12 @@ std::future<std::unique_ptr<Agate::ModelLoader>> Agate::ModelLoader::LoadModel(c
     return std::async(std::launch::async, [path]() {
 
         std::unique_ptr<Agate::ModelLoader> loader = std::make_unique<AssimpLoader>(path);
-        loader->m_futureScene = loader->loadModel();
-
-        loader->m_futureScene.wait();
-        if (loader->m_futureScene.get()) {
-            loader->m_meshes = loader->parseModel();
-            loader->m_model = Agate::ModelEditor(loader->m_path, loader->m_meshes);
-        } else {
-            PRINTWARN("ModelLoader: Model load failed");
-        }
+        loader->loadModel();
+        loader->m_meshes = loader->parseModel();
+        loader->m_model = Agate::ModelEditor(loader->m_path, loader->m_meshes);
 
         return loader;
     });
-
 }
 
 std::string Agate::ModelLoader::extractDirectory(const std::string &path) {

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -13,20 +13,15 @@ Agate::ModelLoader::~ModelLoader() = default;
 Agate::ModelLoader::ModelLoader(std::string const &path)
     : m_directory(extractDirectory(path)), m_path(path) {}
 
-void Agate::ModelLoader::Draw(Agate::Shader &shader) {
-    m_model.Draw(shader);
-}
-
 std::future<std::unique_ptr<Agate::ModelEditor>> Agate::ModelLoader::LoadModel(const std::string &path) {
 
     return std::async(std::launch::async, [path]() {
 
-        std::unique_ptr<Agate::ModelLoader> loader = std::make_unique<AssimpLoader>(path);
+        std::unique_ptr<Agate::ModelLoader> loader = std::make_unique<Agate::AssimpLoader>(path);
         loader->loadModel();
         loader->m_meshes = loader->parseModel();
-        loader->m_model = Agate::ModelEditor(loader->m_path, loader->m_meshes);
 
-        return std::make_unique<ModelEditor>(std::move(loader->m_model));
+        return std::make_unique<Agate::ModelEditor>(Agate::ModelEditor(loader->m_path, loader->m_meshes));
     });
 }
 

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -18,10 +18,15 @@ std::future<std::unique_ptr<Agate::ModelEditor>> Agate::ModelLoader::LoadModel(c
     return std::async(std::launch::async, [path]() {
 
         std::unique_ptr<Agate::ModelLoader> loader = std::make_unique<Agate::AssimpLoader>(path);
-        loader->loadModel();
+        
+        if (!loader->loadModel()) {
+            PRINTWARN("Failed to load model from {}", path);
+
+            return std::unique_ptr<Agate::ModelEditor>(nullptr);
+        }
         loader->m_meshes = loader->parseModel();
 
-        return std::make_unique<Agate::ModelEditor>(Agate::ModelEditor(loader->m_path, loader->m_meshes));
+        return std::make_unique<Agate::ModelEditor>(std::move(loader->m_path), std::move(loader->m_meshes));
     });
 }
 

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -2,6 +2,7 @@
 #include "ModelLoader.h"
 #include "AssimpLoader.h"
 #include "Mesh.h"
+#include "ModelEditor.h"
 #include <utility>
 #include <memory>
 
@@ -28,14 +29,14 @@ void Agate::ModelLoader::Draw(Agate::Shader &shader) {
             // Once this is done the future scene will no longer be valid
             if (m_futureScene.get()) {
                 m_meshes = parseModel();
+                m_model = Agate::ModelEditor(m_path, m_meshes);
             } else {
                 PRINTWARN("ModelLoader: Model load failed");
             }
         }
     }
 
-    for (auto &mesh: m_meshes)
-        mesh.Draw(shader);
+    m_model.Draw(shader);
 }
 
 std::unique_ptr<Agate::ModelLoader> Agate::ModelLoader::LoadModel(const std::string &path) {

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -17,7 +17,7 @@ void Agate::ModelLoader::Draw(Agate::Shader &shader) {
     m_model.Draw(shader);
 }
 
-std::future<std::unique_ptr<Agate::ModelLoader>> Agate::ModelLoader::LoadModel(const std::string &path) {
+std::future<std::unique_ptr<Agate::ModelEditor>> Agate::ModelLoader::LoadModel(const std::string &path) {
 
     return std::async(std::launch::async, [path]() {
 
@@ -26,7 +26,7 @@ std::future<std::unique_ptr<Agate::ModelLoader>> Agate::ModelLoader::LoadModel(c
         loader->m_meshes = loader->parseModel();
         loader->m_model = Agate::ModelEditor(loader->m_path, loader->m_meshes);
 
-        return loader;
+        return std::make_unique<ModelEditor>(std::move(loader->m_model));
     });
 }
 

--- a/Agate/src/Agate/Rendering/ModelLoader.h
+++ b/Agate/src/Agate/Rendering/ModelLoader.h
@@ -19,30 +19,11 @@ namespace Agate {
         std::vector<Mesh> m_meshes;
         std::string m_directory;
         std::string m_path;
-        ModelEditor m_model;
 
         /**
          * @brief Destructor - Blocks and waits for future completion if necessary
          */
         virtual ~ModelLoader();
-
-        /**
-        * @brief Render the model; finalize loading when the async import completes.
-        *
-        * Each frame, this function polls the async import future. When the import
-        * completes, it performs one-time scene preparation (node traversal, mesh
-        * extraction, and any associated buffer creation) by calling prepareScene().
-        * After preparation, it draws all loaded meshes.
-        *
-        * @param shader Shader program used to render the meshes.
-        *
-        * @note Non-blocking: if the import is not ready yet, this function only draws
-        *       meshes that have already been prepared (often none).
-        * 
-        * @warning If `ModelLoader::LoadModel` has not been invoked, this method will
-        *          never do anything
-        */
-        void Draw(Shader &shader);
 
         /**
          * @brief Instructs the loader to start internally loading its model

--- a/Agate/src/Agate/Rendering/ModelLoader.h
+++ b/Agate/src/Agate/Rendering/ModelLoader.h
@@ -50,8 +50,12 @@ protected:
 
         /**
          * @brief Performs the I/O part of loading the model
+         * 
+         * @return Operation status
+         * @retval true Success
+         * @retval false Failure
          */
-        virtual void loadModel() = 0;
+        virtual bool loadModel() = 0;
 
         /**
          * @brief Parses the loaded model into a form that the engine can render

--- a/Agate/src/Agate/Rendering/ModelLoader.h
+++ b/Agate/src/Agate/Rendering/ModelLoader.h
@@ -2,6 +2,7 @@
 #define AGATE_MODELLOADER_H
 
 #include "Mesh.h"
+#include "ModelEditor.h"
 #include "OpenGl/Shader.h"
 #include "OpenGl/Texture.h"
 #include <future>
@@ -18,6 +19,7 @@ namespace Agate {
         std::vector<Mesh> m_meshes;
         std::string m_directory;
         std::string m_path;
+        ModelEditor m_model;
 
         /**
          * @brief Destructor - Blocks and waits for future completion if necessary

--- a/Agate/src/Agate/Rendering/ModelLoader.h
+++ b/Agate/src/Agate/Rendering/ModelLoader.h
@@ -49,7 +49,7 @@ namespace Agate {
          * 
          * @param path Path to the model file
          */
-        static std::future<std::unique_ptr<ModelLoader>> LoadModel(std::string const &path);
+        static std::future<std::unique_ptr<ModelEditor>> LoadModel(std::string const &path);
 
 protected:
 
@@ -80,8 +80,6 @@ protected:
         virtual std::vector<Mesh> parseModel() = 0;
 
     private:
-
-        std::future<void> m_loading;
 
         //helper function
         std::string extractDirectory(const std::string& path);

--- a/Agate/src/Agate/Rendering/ModelLoader.h
+++ b/Agate/src/Agate/Rendering/ModelLoader.h
@@ -49,7 +49,7 @@ namespace Agate {
          * 
          * @param path Path to the model file
          */
-        static std::unique_ptr<ModelLoader> LoadModel(std::string const &path);
+        static std::future<std::unique_ptr<ModelLoader>> LoadModel(std::string const &path);
 
 protected:
 

--- a/Agate/src/Agate/Rendering/ModelLoader.h
+++ b/Agate/src/Agate/Rendering/ModelLoader.h
@@ -68,17 +68,9 @@ protected:
         ModelLoader(std::string const &path);
 
         /**
-         * @brief Starts loading the model this loader was given
-         * 
-         * @return Future that becomes valid upon completion of loading the model
-         *         and indicates operation status
-         * @retval true Success
-         * @retval false Error
-         * 
-         * @note Implementations are encouraged to define this in a non-blocking
-         *       manner
+         * @brief Performs the I/O part of loading the model
          */
-        virtual std::future<bool> loadModel() = 0;
+        virtual void loadModel() = 0;
 
         /**
          * @brief Parses the loaded model into a form that the engine can render
@@ -89,13 +81,7 @@ protected:
 
     private:
 
-        /**
-         * @brief A future for the loaded model is kept as a class member to preserve
-         *        access to the result of the asynchronous load task
-         */
-        std::future<bool> m_futureScene;
-
-    private:
+        std::future<void> m_loading;
 
         //helper function
         std::string extractDirectory(const std::string& path);

--- a/Agate/src/Agate/Rendering/OpenGl/Texture.cpp
+++ b/Agate/src/Agate/Rendering/OpenGl/Texture.cpp
@@ -131,28 +131,8 @@ namespace Agate {
      * @return A Texture object
      */
     Texture::Texture(const char *file, std::string &directory)
-            : m_width(0), m_height(0), m_path(file), m_type("texture"), m_target(GL_TEXTURE_2D), m_textureID(0) {
-        std::string normalizedPath = create_normalized_path(directory, m_path);
-        std::filesystem::path filepath(normalizedPath);
+            : m_width(0), m_height(0), m_path(file), m_type("texture"), m_target(GL_TEXTURE_2D), m_textureID(0), m_directory(directory) {
 
-        // Convert extension to lowercase
-        std::string extension = filepath.extension().string();
-        std::transform(extension.begin(), extension.end(), extension.begin(),
-                                              [](unsigned char c){ return std::tolower(c); });
-
-        if (extension == ".ktx" || extension == ".ktx2") {
-            // Load KTX file using libktx
-            if (!load_ktx_with_libktx(normalizedPath, m_textureID, m_target, m_width, m_height)) {
-                PRINTERROR("Failed to load KTX texture at path: {}", normalizedPath);
-                // Optionally, set a default texture or handle the error gracefully @TODO
-            }
-        } else {
-            // Load standard image using SOIL2
-            if (!load_standard_texture_with_soil2(normalizedPath, m_textureID, m_target, m_width, m_height)) {
-                PRINTERROR("Failed to load standard texture at path: {}", normalizedPath);
-                // Optionally, set a default texture or handle the error gracefully @TODO
-            }
-        }
     }
 
     /*
@@ -203,6 +183,29 @@ namespace Agate {
      */
     void Texture::setType(std::string &typeName) {
         m_type = typeName;
+    }
+
+    void Texture::initialize() {
+        std::string normalizedPath = create_normalized_path(m_directory, m_path);
+        std::filesystem::path filepath(normalizedPath);
+
+        // Convert extension to lowercase
+        std::string extension = filepath.extension().string();
+        std::transform(extension.begin(), extension.end(), extension.begin(),
+                                              [](unsigned char c){ return std::tolower(c); });
+        if (extension == ".ktx" || extension == ".ktx2") {
+            // Load KTX file using libktx
+            if (!load_ktx_with_libktx(normalizedPath, m_textureID, m_target, m_width, m_height)) {
+                PRINTERROR("Failed to load KTX texture at path: {}", normalizedPath);
+                // Optionally, set a default texture or handle the error gracefully @TODO
+            }
+        } else {
+            // Load standard image using SOIL2
+            if (!load_standard_texture_with_soil2(normalizedPath, m_textureID, m_target, m_width, m_height)) {
+                PRINTERROR("Failed to load standard texture at path: {}", normalizedPath);
+                // Optionally, set a default texture or handle the error gracefully @TODO
+            }
+        }
     }
 
 } // namespace Agate

--- a/Agate/src/Agate/Rendering/OpenGl/Texture.h
+++ b/Agate/src/Agate/Rendering/OpenGl/Texture.h
@@ -57,6 +57,12 @@ namespace Agate {
         */
         const std::string &getType();
 
+        /**
+         * @brief Makes OpenGL calls required to prepare
+         *        the rendering context to handle this
+         */
+        void initialize();
+
     private:
         /*
         * Helper function to load standard images using SOIL2
@@ -87,7 +93,7 @@ namespace Agate {
     private:
         unsigned int m_textureID, m_target;
         int m_width, m_height;
-        std::string m_path, m_type;
+        std::string m_path, m_type, m_directory;
     };
 }
 

--- a/Application/src/Application.cpp
+++ b/Application/src/Application.cpp
@@ -97,8 +97,8 @@ public:
 
     Agate::Shader *shader;
     Agate::Camera *camera;
-    Agate::ModelLoader *model;
-    std::future<std::unique_ptr<Agate::ModelLoader>> pendingModel;
+    Agate::ModelEditor *model;
+    std::future<std::unique_ptr<Agate::ModelEditor>> pendingModel;
 };
 
 Agate::EntryPoint *Agate::CreateEntryPoint()

--- a/Application/src/Application.cpp
+++ b/Application/src/Application.cpp
@@ -1,5 +1,6 @@
 
 #include "Agate.h"
+#include <chrono>
 #include <memory>
 #include <filesystem>
 #include <future>

--- a/Application/src/Application.cpp
+++ b/Application/src/Application.cpp
@@ -56,6 +56,7 @@ public:
             const auto status = pendingModel.wait_for(std::chrono::seconds(0));
             if (status == std::future_status::ready) {
                 model = pendingModel.get().release();
+                model->LoadTextures();
             }
         }
 

--- a/Application/src/Application.cpp
+++ b/Application/src/Application.cpp
@@ -2,6 +2,7 @@
 #include "Agate.h"
 #include <memory>
 #include <filesystem>
+#include <future>
 class app : public Agate::EntryPoint {
 
 };
@@ -39,16 +40,25 @@ public:
         camera = new Agate::Camera(*shader);
         camera->setCameraPos({1.0f,1.0f,20.0f});
         camera->setCameraSpeed(10.f);
-        model = Agate::ModelLoader::LoadModel(std::filesystem::path("Shaders/vokselia_spawn/vokselia_spawn.obj").generic_string()).release();
+        model = nullptr;
+        pendingModel = Agate::ModelLoader::LoadModel(std::filesystem::path("Shaders/vokselia_spawn/vokselia_spawn.obj").generic_string());
     }
 
     void Detach() override
     {
-
     }
 
     void OnRender() override
     {
+
+        // Poll for model completion until model is retrieved
+        if (pendingModel.valid()) {
+            const auto status = pendingModel.wait_for(std::chrono::seconds(0));
+            if (status == std::future_status::ready) {
+                model = pendingModel.get().release();
+            }
+        }
+
         shader->Bind();
         camera->onUpdate();
 
@@ -57,7 +67,11 @@ public:
         shader->SetUniform3f("pointLight.Position", camera->getCameraPos().x,camera->getCameraPos().y,camera->getCameraPos().z);    // Position: (x, y, z)
         trans_model = glm::scale(trans_model, glm::vec3(1.0f, 1.5f, 0.55f));    // it's a bit too big for our scene, so scale it down
         shader->SetUniformMat4("model", trans_model);
-        model->Draw(*shader);
+
+        // Only attempt to draw if model has been retrieved
+        if (model) {
+            model->Draw(*shader);
+        }
     }
     void OnEvent(Agate::Event &e) override
     {
@@ -65,11 +79,26 @@ public:
     }
     virtual ~TemplayerEx()
     {
+        if (pendingModel.valid()) {
+            PRINTMSG("[TemplateLayer]: Waiting for pending model");
+            pendingModel.wait();
+            pendingModel.get();
+        }
+        delete shader;
+        shader = nullptr;
+        delete camera;
+        camera = nullptr;
+
+        if (model) {
+            delete model;
+            model = nullptr;
+        }
     }
 
     Agate::Shader *shader;
     Agate::Camera *camera;
     Agate::ModelLoader *model;
+    std::future<std::unique_ptr<Agate::ModelLoader>> pendingModel;
 };
 
 Agate::EntryPoint *Agate::CreateEntryPoint()


### PR DESCRIPTION
Adds a `ModelEditor` class and refactors the `ModelLoader` class to return loaded models as `ModelEditors` instead of owning the model itself.

In order to accomplish this, several other changes are needed:
- Extract asynchronous task polling to the application (from `ModelLoader`)
- Move draw calls from `ModelLoader` to `ModelEditor`
- Move OpenGL calls out of `Mesh` and `Texture` constructors
- Manually issue OpenGL initialization of `Mesh` and `Texture` instances in `ModelEditor`

> [!NOTE]
> The mesh and texture initialization now happens in a blocking manner and takes a significant amount of time on the main thread. When running the test application, this results in a 30-60 second freeze between the model loading and being drawn.

Resolves #68 