### PR TITLE
Add TaskPool (#52)

### DIFF
--- a/Agate/src/Agate.h
+++ b/Agate/src/Agate.h
@@ -35,3 +35,4 @@
 //-----------Async-------------
 #include "Agate/Async/ProcessConcurrency.h"
 #include "Agate/Async/Task.h"
+#include "Agate/Async/TaskState.h"

--- a/Agate/src/Agate.h
+++ b/Agate/src/Agate.h
@@ -33,6 +33,4 @@
 #include "Agate/Rendering/Camera.h"
 
 //-----------Async-------------
-#include "Agate/Async/ProcessConcurrency.h"
-#include "Agate/Async/Task.h"
-#include "Agate/Async/TaskState.h"
+#include "Agate/Async/TaskPool.h"

--- a/Agate/src/Agate.h
+++ b/Agate/src/Agate.h
@@ -34,4 +34,4 @@
 
 //-----------Async-------------
 #include "Agate/Async/ProcessConcurrency.h"
-
+#include "Agate/Async/Task.h"

--- a/Agate/src/Agate.h
+++ b/Agate/src/Agate.h
@@ -32,3 +32,6 @@
 #include "Agate/Rendering/ModelLoader.h"
 #include "Agate/Rendering/Camera.h"
 
+//-----------Async-------------
+#include "Agate/Async/ProcessConcurrency.h"
+

--- a/Agate/src/Agate/Async/ProcessConcurrency.h
+++ b/Agate/src/Agate/Async/ProcessConcurrency.h
@@ -1,0 +1,55 @@
+/**
+ * @brief Include file for process concurrency information
+ */
+
+#ifndef AGATE_PROCESSCONCURRENCY_H
+#define AGATE_PROCESSCONCURRENCY_H
+
+#include <thread>
+#include <algorithm>
+
+#ifdef _WIN32
+    #include <windows.h>
+    #include <bit>
+#elif defined(__linux__)
+    #include <sched.h>
+#endif
+
+namespace Agate {
+
+/**
+ * @brief On Windows and Linux, retrieves the amount of threads available
+ *        to this process. On MacOS/OSX, retrieves the amount of system
+ *        threads available as per `std::thread::hardware_concurrency`
+ */
+unsigned int ProcessConcurrency() {
+#ifdef _WIN32
+
+    // Windows: Process affinity mask is a 64-bit bitset where each set bit is an available thread
+    DWORD_PTR processAffinityMask, systemAffinityMask;
+    if (GetProcessAffinityMask(GetCurrentProcess(), &processAffinityMask, &systemAffinityMask)) {
+        return std::popcount(processAffinityMask);
+    }
+
+#elif defined(__linux__)
+
+    // Linux: sched_getaffinity provides available thread count
+    cpu_set_t cpuset;
+    CPU_ZERO(&cpuset);
+    if (sched_getaffinity(0, sizeof(cpu_set_t), &cpuset) == 0) {
+        return CPU_COUNT(&cpuset);
+    }
+#endif
+
+    // MacOS does not provide thread availability at the process level
+    unsigned int concurrency = std::thread::hardware_concurrency();
+    if (concurrency == 0) {
+        concurrency = 1;
+    }
+
+    return concurrency; 
+}
+
+} // namespace Agate
+
+#endif

--- a/Agate/src/Agate/Async/ProcessConcurrency.h
+++ b/Agate/src/Agate/Async/ProcessConcurrency.h
@@ -22,7 +22,7 @@ namespace Agate {
  *        to this process. On MacOS/OSX, retrieves the amount of system
  *        threads available as per `std::thread::hardware_concurrency`
  */
-unsigned int ProcessConcurrency() {
+inline unsigned int ProcessConcurrency() {
 #ifdef _WIN32
 
     // Windows: Process affinity mask is a 64-bit bitset where each set bit is an available thread

--- a/Agate/src/Agate/Async/Task.h
+++ b/Agate/src/Agate/Async/Task.h
@@ -11,7 +11,7 @@
 namespace Agate {
 
 /**
- * @brief Type erasing wrappper for tasks so that all tasks can
+ * @brief Type erasing wrapper for tasks so that all tasks can
  *        be placed in the task queue
  */
 class Task {

--- a/Agate/src/Agate/Async/Task.h
+++ b/Agate/src/Agate/Async/Task.h
@@ -1,0 +1,59 @@
+/**
+ * @brief Include file for the Task and QualifiedTask classes
+ */
+
+#ifndef AGATE_TASK_H
+#define AGATE_TASK_H
+
+#include <concepts>
+#include <type_traits>
+
+namespace Agate {
+
+/**
+ * @brief Type erasing wrappper for tasks so that all tasks can
+ *        be placed in the task queue
+ */
+class Task {
+public:
+
+    /**
+     * @brief Virtual destructor for subclasses
+     */
+    virtual ~Task() = default;
+
+    /**
+     * @brief Runs the task
+     */
+    virtual void Run() = 0;
+};
+
+/**
+ * @brief A task specialized for a specific function type
+ * 
+ * @tparam FuncType Type of the invocable that runs the task
+ */
+template<typename FuncType>
+    requires std::invocable<FuncType>
+class QualifiedTask : public Task {
+private:
+    FuncType taskFn;
+public:
+
+    /**
+     * @brief Forwarding constructor
+     */
+    QualifiedTask(FuncType&& task)
+        : taskFn(std::forward<FuncType>(task)) {}
+
+    /**
+     * @brief Runs the task
+     */
+    virtual void Run() override {
+        taskFn();
+    }
+};
+
+} // namespace Agate
+
+#endif

--- a/Agate/src/Agate/Async/TaskPool.cpp
+++ b/Agate/src/Agate/Async/TaskPool.cpp
@@ -1,0 +1,57 @@
+#include "TaskPool.h"
+#include "ProcessConcurrency.h"
+
+namespace Agate {
+
+std::once_flag TaskPool::initializationFlag{};
+std::unique_ptr<Agate::TaskPool> TaskPool::instance = nullptr;
+
+TaskPool::TaskPool(unsigned int threadCount) {
+    for (std::size_t i = 0; i < threadCount; ++i) {
+        workers.emplace_back([this]() -> void {
+
+            while (true) {
+                std::unique_ptr<Task> currentTask;
+
+                // Wait until a task is ready, then take it from the queue and do it
+                {
+                    std::unique_lock lock(this->queueLock);
+                    this->queueCondition.wait(lock, [this]() -> bool {
+                        return this->shutdown.load() || !(this->taskQueue.empty());
+                    });
+
+                    // Shutdown
+                    if (this->shutdown.load()) {
+                        return;
+                    }
+
+                    currentTask = std::move(this->taskQueue.front());
+                    this->taskQueue.pop();
+                }
+
+                currentTask->Run();
+            }
+        });
+    }
+}
+
+TaskPool::~TaskPool() {
+    shutdown.store(true);
+    queueCondition.notify_all();
+}
+
+void TaskPool::Initialize() {
+
+    std::call_once(initializationFlag, []() -> void {
+
+        unsigned int threadCount = ProcessConcurrency();
+        if (threadCount <= 2U) {
+            threadCount = 1;
+        } else {
+            threadCount -= 2U;
+        }
+        instance.reset(new TaskPool(threadCount));
+    });
+}
+
+} // namespace Agate

--- a/Agate/src/Agate/Async/TaskPool.cpp
+++ b/Agate/src/Agate/Async/TaskPool.cpp
@@ -20,8 +20,13 @@ TaskPool::TaskPool(unsigned int threadCount) {
                         return this->shutdown.load() || !(this->taskQueue.empty());
                     });
 
-                    // Shutdown
+                    // Shutdown - First worker to hit this will flush the queue
                     if (this->shutdown.load()) {
+                        while (!this->taskQueue.empty()) {
+                            currentTask = std::move(this->taskQueue.front());
+                            this->taskQueue.pop();
+                            currentTask->Run();
+                        }
                         return;
                     }
 

--- a/Agate/src/Agate/Async/TaskPool.h
+++ b/Agate/src/Agate/Async/TaskPool.h
@@ -122,12 +122,12 @@ template<typename ResultType>
 ResultType TaskHandle<ResultType>::Get() {
 
     // Critical error: Invalid access attempt
+    std::scoped_lock lock(sharedState->mutex);
     if (!sharedState->result.has_value() || Status() != TaskStatus::Done) {
         PRINTCRIT("Attempted to call `TaskHandle::Get` with an invalid result");
         throw std::runtime_error("Invalid std::optional access attempt");
     }
 
-    std::scoped_lock lock(sharedState->mutex);
     ResultType result = std::move(*(sharedState->result));
     sharedState->result.reset();
     return result;

--- a/Agate/src/Agate/Async/TaskPool.h
+++ b/Agate/src/Agate/Async/TaskPool.h
@@ -152,7 +152,7 @@ private:
     std::condition_variable queueCondition;
     std::queue<std::unique_ptr<Task>> taskQueue;
 
-    std::atomic<bool> shutdown;
+    std::atomic<bool> shutdown = false;
     std::vector<std::jthread> workers;
 
     /**

--- a/Agate/src/Agate/Async/TaskPool.h
+++ b/Agate/src/Agate/Async/TaskPool.h
@@ -53,11 +53,12 @@ public:
         std::scoped_lock lock(sharedState->mutex);
         bool statusDone = static_cast<std::uint32_t>(sharedState->status.load() & TaskStatus::Done) == static_cast<std::uint32_t>(TaskStatus::Done);
         if (sharedState->result.has_value() && statusDone) {
-            callback(*(sharedState->result));
+            *(sharedState->result) = callback(std::move(*(sharedState->result)));
 
             return *this;
         }
-        sharedState->callback = std::make_unique(callback);
+        auto callbackPtr = std::make_unique<QualifiedCallback<ResultType, FuncType>>(std::forward<FuncType>(callback));
+        sharedState->callback = std::move(callbackPtr);
 
         return *this;
     }

--- a/Agate/src/Agate/Async/TaskPool.h
+++ b/Agate/src/Agate/Async/TaskPool.h
@@ -34,8 +34,7 @@ private:
     std::shared_ptr<QualifiedTaskState<ResultType>> sharedState;
 public:
 
-    TaskHandle(std::shared_ptr<QualifiedTaskState<ResultType>> state = nullptr)
-        : sharedState(state) {}
+    TaskHandle(std::shared_ptr<QualifiedTaskState<ResultType>> state = nullptr);
 
     /**
      * @brief Assigns a callback to be executed upon task completion
@@ -48,20 +47,7 @@ public:
      * @return Reference to this handle for call chaining
      */
     template<typename FuncType>
-    TaskHandle<ResultType>& Then(FuncType&& callback) {
-
-        std::scoped_lock lock(sharedState->mutex);
-        bool statusDone = static_cast<std::uint32_t>(sharedState->status.load() & TaskStatus::Done) == static_cast<std::uint32_t>(TaskStatus::Done);
-        if (sharedState->result.has_value() && statusDone) {
-            callback(*(sharedState->result));
-
-            return *this;
-        }
-        auto callbackPtr = std::make_unique<QualifiedCallback<ResultType, FuncType>>(std::forward<FuncType>(callback));
-        sharedState->callback = std::move(callbackPtr);
-
-        return *this;
-    }
+    TaskHandle<ResultType>& Then(FuncType&& callback);
 
     /**
      * @brief Blocks execution until the task for this handle is in a
@@ -71,16 +57,7 @@ public:
      * 
      * @return Reference to this handle for call chaining
      */
-    TaskHandle<ResultType>& Wait() {
-
-        std::unique_lock lock(sharedState->mutex);
-        sharedState->condition.wait(lock, [this]() -> bool {
-            bool statusTerminal = static_cast<std::uint32_t>(sharedState->status.load() & TaskStatus::Terminal) != static_cast<std::uint32_t>(0);
-            return statusTerminal;
-        });
-
-        return *this;
-    }
+    TaskHandle<ResultType>& Wait();
 
     /**
      * @brief Attempts to extract the result from the task for
@@ -88,28 +65,70 @@ public:
      * 
      * @return Result of the completed task
      */
-    ResultType Get() {
-
-        // Critical error: Invalid access attempt
-        if (!sharedState->result.has_value()) {
-            PRINTCRIT("Attempted to call `TaskHandle::Get` with an invalid result");
-            throw std::runtime_error("Invalid std::optional access attempt");
-        }
-
-        ResultType result = std::move(*(sharedState->result));
-        sharedState->result.reset();
-        return result;
-    }
+    ResultType Get();
 
     /**
      * @brief Cancels the task. If the task is currently running, it is stopped
      *        and set to a cancelled status. Otherwise, the task is set to a
      *        cancelled status
      */
-    void Cancel() {
-        PRINTWARN("TaskHandle::Cancel not yet implemented");
-    }
+    void Cancel();
 };
+
+// Note: Definitions must be outside of the class for MSVC builds
+
+template<typename ResultType>
+TaskHandle<ResultType>::TaskHandle(std::shared_ptr<QualifiedTaskState<ResultType>> state)
+    : sharedState(state) {}
+
+template<typename ResultType>
+template<typename FuncType>
+TaskHandle<ResultType>& TaskHandle<ResultType>::Then(FuncType&& callback) {
+
+    std::scoped_lock lock(sharedState->mutex);
+    bool statusDone = static_cast<std::uint32_t>(sharedState->status.load() & TaskStatus::Done) == static_cast<std::uint32_t>(TaskStatus::Done);
+    if (sharedState->result.has_value() && statusDone) {
+        callback(*(sharedState->result));
+
+        return *this;
+    }
+    auto callbackPtr = std::make_unique<QualifiedCallback<ResultType, FuncType>>(std::forward<FuncType>(callback));
+    sharedState->callback = std::move(callbackPtr);
+
+    return *this;
+}
+
+
+template<typename ResultType>
+TaskHandle<ResultType>& TaskHandle<ResultType>::Wait() {
+
+    std::unique_lock lock(sharedState->mutex);
+    sharedState->condition.wait(lock, [this]() -> bool {
+        bool statusTerminal = static_cast<std::uint32_t>(sharedState->status.load() & TaskStatus::Terminal) != static_cast<std::uint32_t>(0);
+        return statusTerminal;
+    });
+
+    return *this;
+}
+
+template<typename ResultType>
+ResultType TaskHandle<ResultType>::Get() {
+
+    // Critical error: Invalid access attempt
+    if (!sharedState->result.has_value()) {
+        PRINTCRIT("Attempted to call `TaskHandle::Get` with an invalid result");
+        throw std::runtime_error("Invalid std::optional access attempt");
+    }
+
+    ResultType result = std::move(*(sharedState->result));
+    sharedState->result.reset();
+    return result;
+}
+
+template<typename ResultType>
+void TaskHandle<ResultType>::Cancel() {
+    PRINTWARN("TaskHandle::Cancel not yet implemented");
+}
 
 class TaskPool {
 private:

--- a/Agate/src/Agate/Async/TaskPool.h
+++ b/Agate/src/Agate/Async/TaskPool.h
@@ -1,0 +1,223 @@
+/**
+ * @brief Include file for the task pool
+ * 
+ * Interface and wrapper for dispatching and handling the
+ * cleanup of asynchronous tasks
+ */
+
+#ifndef AGATE_TASKPOOL_H
+#define AGATE_TASKPOOL_H
+
+#include "Agate/Core/Logger.h"
+#include "Task.h"
+#include "TaskState.h"
+#include <concepts>
+#include <memory>
+#include <queue>
+#include <stdexcept>
+#include <thread>
+#include <type_traits>
+#include <vector>
+
+namespace Agate {
+
+/**
+ * @brief Handle for tracking a task and eventually either extracting
+ *        its result or assigning a callback to be executed with the
+ *        result
+ * 
+ * @tparam ResultType Type returned by the task
+ */
+template<typename ResultType>
+class TaskHandle {
+private:
+    std::shared_ptr<QualifiedTaskState<ResultType>> sharedState;
+public:
+
+    TaskHandle(std::shared_ptr<QualifiedTaskState<ResultType>> state = nullptr)
+        : sharedState(state) {}
+
+    /**
+     * @brief Assigns a callback to be executed upon task completion
+     * 
+     * @note If this method is called on a completed task, the callback
+     *       is immediately called
+     * 
+     * @param callback Callback to pass task result to
+     * 
+     * @return Reference to this handle for call chaining
+     */
+    template<typename FuncType>
+    TaskHandle<ResultType>& Then(FuncType&& callback) {
+
+        std::scoped_lock lock(sharedState->mutex);
+        bool statusDone = static_cast<std::uint32_t>(sharedState->status.load() & TaskStatus::Done) == static_cast<std::uint32_t>(TaskStatus::Done);
+        if (sharedState->result.has_value() && statusDone) {
+            callback(*(sharedState->result));
+
+            return *this;
+        }
+        sharedState->callback = std::make_unique(callback);
+
+        return *this;
+    }
+
+    /**
+     * @brief Blocks execution until the task for this handle is in a
+     *        terminal state
+     * 
+     * Terminal states are `Done`, `Error`, and `Cancelled`
+     * 
+     * @return Reference to this handle for call chaining
+     */
+    TaskHandle<ResultType>& Wait() {
+
+        std::unique_lock lock(sharedState->mutex);
+        sharedState->condition.wait(lock, [this]() -> bool {
+            bool statusTerminal = static_cast<std::uint32_t>(sharedState->status.load() & TaskStatus::Terminal) != static_cast<std::uint32_t>(0);
+            return statusTerminal;
+        });
+
+        return *this;
+    }
+
+    /**
+     * @brief Attempts to extract the result from the task for
+     *        this handle. Throws if the result is invalid
+     * 
+     * @return Result of the completed task
+     */
+    ResultType Get() {
+
+        // Critical error: Invalid access attempt
+        if (!sharedState->result.has_value()) {
+            PRINTCRIT("Attempted to call `TaskHandle::Get` with an invalid result");
+            throw std::runtime_error("Invalid std::optional access attempt");
+        }
+
+        return std::move(*(sharedState->result));
+    }
+
+    /**
+     * @brief Cancels the task. If the task is currently running, it is stopped
+     *        and set to a cancelled status. Otherwise, the task is set to a
+     *        cancelled status
+     */
+    void Cancel() {
+        PRINTWARN("TaskHandle::Cancel not yet implemented");
+    }
+};
+
+class TaskPool {
+private:
+
+    static std::once_flag initializationFlag;
+    static std::unique_ptr<TaskPool> instance;
+
+    std::mutex queueLock;
+    std::condition_variable queueCondition;
+    std::queue<std::unique_ptr<Task>> taskQueue;
+
+    std::atomic<bool> shutdown;
+    std::vector<std::jthread> workers;
+
+    /**
+     * @brief Singleton constructor - initializes worker threads
+     */
+    TaskPool(unsigned int threadCount);
+
+public:
+
+    /**
+     * @brief Destructor - shuts down worker threads and flushes
+     *        pending tasks
+     */
+    ~TaskPool();
+
+    /**
+     * @brief Delete copy constructor for singleton
+     */
+    TaskPool(const TaskPool&) = delete;
+
+    /**
+     * @brief Delete move constructor for singleton
+     */
+    TaskPool& operator=(const TaskPool&) = delete;
+
+    /**
+     * @brief Initializes the singleton instance of the task pool
+     * 
+     * @note This method should be called only once at startup and
+     *       must be called before enqueueing any tasks
+     */
+    static void Initialize();
+
+    /**
+     * @brief Submits a task to the task pool
+     * 
+     * @tparam TaskFunc Type of the invocable task
+     * @tparam Args Types of the arguments to be passed to the invocable task
+     * 
+     * @param task Task to submit
+     * @param args Arguments to bind to the task (if applicable)
+     * 
+     * @return Handle linked to the task for cancellation, extraction, or continuation
+     */
+    template<typename TaskFunc, typename... Args>
+        requires std::invocable<TaskFunc, Args...>
+    static TaskHandle<std::invoke_result_t<std::decay_t<TaskFunc>, std::decay_t<Args>...>> 
+    Enqueue(TaskFunc&& task, Args&&... args) {
+
+        using ResultType = std::invoke_result_t<std::decay_t<TaskFunc>, std::decay_t<Args>...>;
+
+        std::shared_ptr<QualifiedTaskState<ResultType>> state = std::make_shared<QualifiedTaskState<ResultType>>();
+        TaskHandle<ResultType> handle{ state };
+
+        // Wrap the task with logic to safely store its result in the handle's state
+        auto boundTask = [
+            task = std::forward<TaskFunc>(task),
+            arguments = std::make_tuple(std::forward<Args>(args)...)
+        ]() mutable -> ResultType {
+            return std::apply(task, arguments);
+        };
+        auto wrappedTask = [
+            state,
+            task = std::move(boundTask)
+        ]() mutable {
+
+            // Task cancelled before running
+            if ((state->status.load() & TaskStatus::CancelRequested) == TaskStatus::CancelRequested) {
+                state->status.store(TaskStatus::Cancelled);
+                state->condition.notify_all();
+
+                return;
+            }
+
+            ResultType result = task();
+
+            // Safely store result
+            {
+                std::scoped_lock lock(state->mutex);
+                state->result = std::move(result);
+                state->status.store(TaskStatus::Done);
+                if (state->callback) {
+                    state->callback->Run(*(state->result));
+                }
+            }
+            state->condition.notify_all();
+        };
+
+        // Package and enqueue task, then alert workers
+        std::unique_ptr<Task> packedTask = std::make_unique<QualifiedTask<decltype(wrappedTask)>>(std::move(wrappedTask));
+        {
+            std::scoped_lock lock(instance->queueLock);
+            instance->taskQueue.push(std::move(packedTask));
+        }
+        instance->queueCondition.notify_one();
+
+        return handle;
+    }
+};
+} // namespace Agate
+
+#endif

--- a/Agate/src/Agate/Async/TaskPool.h
+++ b/Agate/src/Agate/Async/TaskPool.h
@@ -96,7 +96,9 @@ public:
             throw std::runtime_error("Invalid std::optional access attempt");
         }
 
-        return std::move(*(sharedState->result));
+        ResultType result = std::move(*(sharedState->result));
+        sharedState->result.reset();
+        return result;
     }
 
     /**

--- a/Agate/src/Agate/Async/TaskPool.h
+++ b/Agate/src/Agate/Async/TaskPool.h
@@ -207,6 +207,13 @@ public:
         std::shared_ptr<QualifiedTaskState<ResultType>> state = std::make_shared<QualifiedTaskState<ResultType>>();
         TaskHandle<ResultType> handle{ state };
 
+        // Task pool invalid
+        if (!instance || instance->shutdown.load()) {
+            state->status.store(TaskStatus::Error);
+
+            return TaskHandle<ResultType>(state);
+        }
+
         // Wrap the task with logic to safely store its result in the handle's state
         auto boundTask = [
             task = std::forward<TaskFunc>(task),

--- a/Agate/src/Agate/Async/TaskPool.h
+++ b/Agate/src/Agate/Async/TaskPool.h
@@ -244,7 +244,10 @@ public:
                 state->condition.notify_all();
 
             } catch (const std::exception& exception) {
-                state->status.store(TaskStatus::Error);
+                {
+                    std::scoped_lock lock(state->mutex);
+                    state->status.store(TaskStatus::Error);
+                }
                 state->condition.notify_all();
             }
         };

--- a/Agate/src/Agate/Async/TaskPool.h
+++ b/Agate/src/Agate/Async/TaskPool.h
@@ -73,6 +73,13 @@ public:
      *        cancelled status
      */
     void Cancel();
+
+    /**
+     * @brief Queries the current status of this handle's task
+     * 
+     * @return Current task status
+     */
+    inline TaskStatus Status() const;
 };
 
 // Note: Definitions must be outside of the class for MSVC builds
@@ -128,6 +135,11 @@ ResultType TaskHandle<ResultType>::Get() {
 template<typename ResultType>
 void TaskHandle<ResultType>::Cancel() {
     PRINTWARN("TaskHandle::Cancel not yet implemented");
+}
+
+template<typename ResultType>
+inline TaskStatus TaskHandle<ResultType>::Status() const {
+    return sharedState->status.load();
 }
 
 class TaskPool {

--- a/Agate/src/Agate/Async/TaskPool.h
+++ b/Agate/src/Agate/Async/TaskPool.h
@@ -53,7 +53,7 @@ public:
         std::scoped_lock lock(sharedState->mutex);
         bool statusDone = static_cast<std::uint32_t>(sharedState->status.load() & TaskStatus::Done) == static_cast<std::uint32_t>(TaskStatus::Done);
         if (sharedState->result.has_value() && statusDone) {
-            *(sharedState->result) = callback(std::move(*(sharedState->result)));
+            callback(*(sharedState->result));
 
             return *this;
         }

--- a/Agate/src/Agate/Async/TaskPool.h
+++ b/Agate/src/Agate/Async/TaskPool.h
@@ -215,18 +215,26 @@ public:
                 return;
             }
 
-            ResultType result = task();
+            try {
 
-            // Safely store result
-            {
-                std::scoped_lock lock(state->mutex);
-                state->result = std::move(result);
-                state->status.store(TaskStatus::Done);
-                if (state->callback) {
-                    state->callback->Run(*(state->result));
+                state->status.store(TaskStatus::Working);
+                ResultType result = task();
+
+                // Safely store result
+                {
+                    std::scoped_lock lock(state->mutex);
+                    state->result = std::move(result);
+                    state->status.store(TaskStatus::Done);
+                    if (state->callback) {
+                        state->callback->Run(*(state->result));
+                    }
                 }
+                state->condition.notify_all();
+
+            } catch (const std::exception& exception) {
+                state->status.store(TaskStatus::Error);
+                state->condition.notify_all();
             }
-            state->condition.notify_all();
         };
 
         // Package and enqueue task, then alert workers

--- a/Agate/src/Agate/Async/TaskPool.h
+++ b/Agate/src/Agate/Async/TaskPool.h
@@ -163,8 +163,8 @@ private:
 public:
 
     /**
-     * @brief Destructor - shuts down worker threads and flushes
-     *        pending tasks
+     * @brief Destructor - flushes and cancels remaining tasks,
+     *        and shuts down worker threads
      */
     ~TaskPool();
 
@@ -219,6 +219,15 @@ public:
             task = std::move(boundTask)
         ]() mutable {
 
+            // Pool shutting down
+            if (ShuttingDown()) {
+                std::scoped_lock lock(state->mutex);
+                state->status.store(TaskStatus::Cancelled);
+                state->condition.notify_all();
+
+                return;
+            }
+
             // Task cancelled before running
             if ((state->status.load() & TaskStatus::CancelRequested) == TaskStatus::CancelRequested) {
                 state->status.store(TaskStatus::Cancelled);
@@ -261,6 +270,15 @@ public:
         instance->queueCondition.notify_one();
 
         return handle;
+    }
+
+private:
+
+    /**
+     * @brief Private static accessor for shutdown for task usage
+     */
+    static bool ShuttingDown() {
+        return instance && instance->shutdown.load();
     }
 };
 } // namespace Agate

--- a/Agate/src/Agate/Async/TaskPool.h
+++ b/Agate/src/Agate/Async/TaskPool.h
@@ -122,11 +122,12 @@ template<typename ResultType>
 ResultType TaskHandle<ResultType>::Get() {
 
     // Critical error: Invalid access attempt
-    if (!sharedState->result.has_value()) {
+    if (!sharedState->result.has_value() || Status() != TaskStatus::Done) {
         PRINTCRIT("Attempted to call `TaskHandle::Get` with an invalid result");
         throw std::runtime_error("Invalid std::optional access attempt");
     }
 
+    std::scoped_lock lock(sharedState->mutex);
     ResultType result = std::move(*(sharedState->result));
     sharedState->result.reset();
     return result;

--- a/Agate/src/Agate/Async/TaskPool.h
+++ b/Agate/src/Agate/Async/TaskPool.h
@@ -199,7 +199,7 @@ public:
      * @return Handle linked to the task for cancellation, extraction, or continuation
      */
     template<typename TaskFunc, typename... Args>
-        requires std::invocable<TaskFunc, Args...>
+        requires std::invocable<std::decay_t<TaskFunc>, std::decay_t<Args>...>
     static TaskHandle<std::invoke_result_t<std::decay_t<TaskFunc>, std::decay_t<Args>...>> 
     Enqueue(TaskFunc&& task, Args&&... args) {
 

--- a/Agate/src/Agate/Async/TaskPool.h
+++ b/Agate/src/Agate/Async/TaskPool.h
@@ -143,7 +143,7 @@ public:
     TaskPool(const TaskPool&) = delete;
 
     /**
-     * @brief Delete move constructor for singleton
+     * @brief Delete copy assignment for singleton
      */
     TaskPool& operator=(const TaskPool&) = delete;
 

--- a/Agate/src/Agate/Async/TaskState.h
+++ b/Agate/src/Agate/Async/TaskState.h
@@ -64,7 +64,7 @@ public:
     /**
      * @brief Invokes the callback with the result of the task
      */
-    virtual void Run(ResultType& result) = 0;
+    virtual void Run(ResultType result) = 0;
 };
 
 /**
@@ -93,7 +93,7 @@ public:
     /**
      * @brief Invokes the callback with the result of the task
      */
-    virtual void Run(ResultType& result) override {
+    virtual void Run(ResultType result) override {
         callback(result);
     }
 };

--- a/Agate/src/Agate/Async/TaskState.h
+++ b/Agate/src/Agate/Async/TaskState.h
@@ -1,0 +1,123 @@
+/**
+ * @brief Include file for asynchronous task shared state
+ */
+
+#ifndef AGATE_TASKSTATE_H
+#define AGATE_TASKSTATE_H
+
+#include <atomic>
+#include <concepts>
+#include <condition_variable>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <type_traits>
+
+
+namespace Agate {
+
+/**
+ * @brief Descriptor for the current status of a task
+ */
+enum class TaskStatus : std::uint32_t {
+    Ready               = 0,                        /*!< Task is in a queue and awaiting a worker to run it */
+    Working             = 1 << 0,                   /*!< Task is being run by a worker thread */
+    Done                = 1 << 1,                   /*!< Task has finished running and its result is ready for extraction */
+    CancelRequested     = 1 << 2,                   /*!< Task has received a cancellation request */
+    Cancelled           = 1 << 3,                   /*!< Task has stopped running due to being cancelled */
+    Error               = 1 << 4,                   /*!< Task has stopped running due encountering an error state */
+    Terminal            = Error | Cancelled | Done  /*!< Task is in a terminal state - The task pool has discarded it */
+};
+
+constexpr inline TaskStatus operator|(TaskStatus left, TaskStatus right) {
+    return static_cast<TaskStatus>(
+        static_cast<std::uint32_t>(left) |
+        static_cast<std::uint32_t>(right)
+    );
+}
+
+constexpr inline TaskStatus operator&(TaskStatus left, TaskStatus right) {
+    return static_cast<TaskStatus>(
+        static_cast<std::uint32_t>(left) &
+        static_cast<std::uint32_t>(right)
+    );
+}
+
+/**
+ * @brief Type erasing wrapper for task callbacks so that anything
+ *        that can be invoked using the qualified result type can
+ *        be contained in a qualified task state
+ * 
+ * @tparam ResultType Type returned by the task (and therefore, the
+ *         type this callback takes as a parameter)
+ */
+template<typename ResultType>
+class TaskCallback {
+public:
+    /**
+     * @brief Virtual destructor for subclasses
+     */
+    virtual ~TaskCallback() = default;
+
+    /**
+     * @brief Invokes the callback with the result of the task
+     */
+    virtual void Run(ResultType& result) = 0;
+};
+
+/**
+ * @brief A callback specialized for a specific function type
+ * 
+ * @tparam ResultType Type returned by the task (and therefore, the
+ *         type this callback takes as a parameter)
+ * 
+ * @tparam FuncType Type of the callback invocable
+ */
+template<typename ResultType, typename FuncType>
+    requires std::invocable<FuncType, ResultType>
+class QualifiedCallback : public TaskCallback<ResultType> {
+private:
+    FuncType callback;
+public:
+
+    /**
+     * @brief Forwarding constructor
+     * 
+     * @param callback Invocable to 
+     */
+    QualifiedCallback(FuncType&& callback)
+        : callback(std::forward<FuncType>(callback)) {}
+    
+    /**
+     * @brief Invokes the callback with the result of the task
+     */
+    virtual void Run(ResultType& result) override {
+        callback(result);
+    }
+};
+
+/**
+ * @brief Shared state wrapper for qualified tasks
+ * 
+ * Contains a pointer to the result type along with
+ * concurrency primitives to allow the task pool and
+ * main thread to safely access the status and result
+ * of a qualified task
+ * 
+ * @tparam ResultType Type returned by the task
+ */
+template<typename ResultType>
+struct QualifiedTaskState {
+
+    std::optional<ResultType> result;
+    std::unique_ptr<TaskCallback<ResultType>> callback;
+
+    std::mutex mutex;
+    std::condition_variable condition;
+    std::atomic<TaskStatus> status;
+};
+
+} // namespace Agate
+
+#endif

--- a/Agate/src/Agate/Async/TaskState.h
+++ b/Agate/src/Agate/Async/TaskState.h
@@ -26,7 +26,7 @@ enum class TaskStatus : std::uint32_t {
     Done                = 1 << 1,                   /*!< Task has finished running and its result is ready for extraction */
     CancelRequested     = 1 << 2,                   /*!< Task has received a cancellation request */
     Cancelled           = 1 << 3,                   /*!< Task has stopped running due to being cancelled */
-    Error               = 1 << 4,                   /*!< Task has stopped running due encountering an error state */
+    Error               = 1 << 4,                   /*!< Task has stopped running due to encountering an error state */
     InCallback          = 1 << 5,                   /*!< Task has finished, but is executing a callback */
     Terminal            = Error | Cancelled | Done  /*!< Task is in a terminal state - The task pool has discarded it */
 };
@@ -85,7 +85,7 @@ public:
     /**
      * @brief Forwarding constructor
      * 
-     * @param callback Invocable to 
+     * @param callback Invocable to pass task result to when the callback is run
      */
     QualifiedCallback(FuncType&& callback)
         : callback(std::forward<FuncType>(callback)) {}

--- a/Agate/src/Agate/Async/TaskState.h
+++ b/Agate/src/Agate/Async/TaskState.h
@@ -27,6 +27,7 @@ enum class TaskStatus : std::uint32_t {
     CancelRequested     = 1 << 2,                   /*!< Task has received a cancellation request */
     Cancelled           = 1 << 3,                   /*!< Task has stopped running due to being cancelled */
     Error               = 1 << 4,                   /*!< Task has stopped running due encountering an error state */
+    InCallback          = 1 << 5,                   /*!< Task has finished, but is executing a callback */
     Terminal            = Error | Cancelled | Done  /*!< Task is in a terminal state - The task pool has discarded it */
 };
 

--- a/Agate/src/Agate/Async/TaskState.h
+++ b/Agate/src/Agate/Async/TaskState.h
@@ -116,7 +116,7 @@ struct QualifiedTaskState {
 
     std::mutex mutex;
     std::condition_variable condition;
-    std::atomic<TaskStatus> status;
+    std::atomic<TaskStatus> status = TaskStatus::Ready;
 };
 
 } // namespace Agate

--- a/Agate/src/Agate/Core/Main.h
+++ b/Agate/src/Agate/Core/Main.h
@@ -7,11 +7,14 @@
 #ifndef AGATE_MAIN_H
 #define AGATE_MAIN_H
 
+#include "Agate/Async/TaskPool.h"
+
 //-----------------------------------------Main Entry -----------------------------------
 extern Agate::EntryPoint *Agate::CreateEntryPoint();
 
 int main() {
     Agate::Logger::initLogger();
+    Agate::TaskPool::Initialize();
 
     Agate::EntryPoint *application = Agate::CreateEntryPoint();
     application->Run();

--- a/Application/src/Application.cpp
+++ b/Application/src/Application.cpp
@@ -112,7 +112,6 @@ public:
 
     void Attach() override
     {
-        Agate::TaskPool::Initialize();
         messageHandle = Agate::TaskPool::Enqueue([]() -> std::string {
             return "Hello from Task Land";
         });

--- a/Application/src/Application.cpp
+++ b/Application/src/Application.cpp
@@ -95,7 +95,7 @@ public:
 };
 
 class TaskTestLayer : public Agate::Layer {
-private:;
+private:
     std::atomic<int> taskCounter{ 0 };
     std::array<Agate::TaskHandle<std::size_t>, 5> taskHandles;
     Agate::TaskHandle<std::string> messageHandle;

--- a/Application/src/Application.cpp
+++ b/Application/src/Application.cpp
@@ -14,42 +14,10 @@ public:
     void Attach() override
     {
         PRINTMSG("Attached example layer");
-        PRINTMSG("Detected Process Concurrency: {}", Agate::ProcessConcurrency());
     }
 
     void Detach() override
     {
-
-        // Test making a task
-        {
-            auto taskFn = []() -> int {
-                PRINTMSG("Hello from Task Land");
-                return 0;
-            };
-            using FnType = decltype(taskFn);
-            using CleanType = std::decay_t<FnType>;
-            std::unique_ptr<Agate::Task> task = std::make_unique<Agate::QualifiedTask<CleanType>>(std::forward<FnType>(taskFn));
-            task->Run();
-        }
-
-        // Test making a task's callback and state
-        {
-            auto integerCallback = [](int result) -> void {
-                PRINTMSG("Callback land reports a result of {}", result);
-            };
-            using FnType = decltype(integerCallback);
-            using CleanType = std::decay_t<FnType>;
-            std::unique_ptr<Agate::TaskCallback<int>> callback 
-                    = std::make_unique<Agate::QualifiedCallback<int, CleanType>>(
-                std::forward<FnType>(integerCallback)
-            );
-            std::unique_ptr<Agate::QualifiedTaskState<int>> state
-                    = std::make_unique<Agate::QualifiedTaskState<int>>();
-            state->callback = std::move(callback);
-            state->result.emplace(1);
-            state->callback->Run(*(state->result));
-        }
-
         PRINTMSG("Detach example layer");
     }
 
@@ -126,16 +94,58 @@ public:
     std::future<std::unique_ptr<Agate::ModelEditor>> pendingModel;
 };
 
-Agate::EntryPoint *Agate::CreateEntryPoint()
+class TaskTestLayer : public Agate::Layer {
+private:;
+    std::atomic<int> taskCounter{ 0 };
+    std::array<Agate::TaskHandle<std::size_t>, 5> taskHandles;
+    Agate::TaskHandle<std::string> messageHandle;
+public:
+
+    void Attach() override
+    {
+        Agate::TaskPool::Initialize();
+        messageHandle = Agate::TaskPool::Enqueue([]() -> std::string {
+            return "Hello from Task Land";
+        });
+        for (std::size_t i = 0; i < 5; ++i) {
+            taskHandles[i] = Agate::TaskPool::Enqueue([this, i]() -> std::size_t {
+                std::this_thread::sleep_for(std::chrono::seconds(5 - i));
+                this->taskCounter++;
+                return this->taskCounter.load();
+            });
+        }
+    }
+
+    void Detach() override
+    {
+        for (std::size_t i = 0; i < 5; ++i) {
+            PRINTMSG("Task {} finished in position {}", i, taskHandles[i].Wait().Get());
+        }
+        PRINTMSG("{}", messageHandle.Get());
+    }
+
+    void OnRender()override
+    {
+    };
+
+    void OnEvent(Agate::Event &e) override
+    {
+    }
+};
+
+Agate::EntryPoint* Agate::CreateEntryPoint()
 {
     auto Application = new app();
 
     std::shared_ptr<layerEx> example_layer = std::make_shared<layerEx>();
+    std::shared_ptr<TaskTestLayer> taskTestLayer = std::make_shared<TaskTestLayer>();
 
     Application->EmplaceLayer(example_layer);
     Application->EmplaceLayer(std::make_shared<TemplayerEx>());
+    Application->EmplaceLayer(taskTestLayer);
 
     Application->RemoveLayer(example_layer);
+    Application->RemoveLayer(taskTestLayer);
 
     return Application;
 }

--- a/Application/src/Application.cpp
+++ b/Application/src/Application.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <filesystem>
 #include <future>
+#include <stdexcept>
 #include <string>
 
 class app : public Agate::EntryPoint {
@@ -126,21 +127,19 @@ public:
         secretMessageHandle = Agate::TaskPool::Enqueue([this]() -> std::string {
             std::this_thread::sleep_for(std::chrono::seconds(3));
             return std::string(*this->originalMessage);
-        }).Then([this](std::string result) -> std::string {
+        }).Then([this](std::string result) -> void {
             result = *this->modifiedMessage;
-            return std::move(result);
         });
 
         secondSecretMessageHandle = Agate::TaskPool::Enqueue([this]() -> std::shared_ptr<std::string> {
             std::this_thread::sleep_for(std::chrono::seconds(4));
             return std::make_shared<std::string>(*this->originalMessage);
-        }).Then([this](std::shared_ptr<std::string> result) -> std::shared_ptr<std::string> {
+        }).Then([this](std::shared_ptr<std::string> result) -> void {
             *result = *this->modifiedMessage;
-            return std::move(result);
         });
 
         iWillFail = Agate::TaskPool::Enqueue([]() -> int {
-            throw std::exception("I failed");
+            throw std::runtime_error("I failed");
             return 0;
         });
     }

--- a/Application/src/Application.cpp
+++ b/Application/src/Application.cpp
@@ -154,7 +154,7 @@ public:
         PRINTMSG("Secret Message: {}", secretMessageHandle.Wait().Get());
         PRINTMSG("Second Secret Message: {}", *secondSecretMessageHandle.Wait().Get());
 
-        if ((iWillFail.Status() & Agate::TaskStatus::Error) == Agate::TaskStatus::Error) {
+        if ((iWillFail.Wait().Status() & Agate::TaskStatus::Error) == Agate::TaskStatus::Error) {
             PRINTMSG("iWillFail failed");
         } else {
             PRINTMSG("iWillFail did not fail");

--- a/Application/src/Application.cpp
+++ b/Application/src/Application.cpp
@@ -141,7 +141,7 @@ public:
         for (std::size_t i = 0; i < 5; ++i) {
             PRINTMSG("Task {} finished in position {}", i, taskHandles[i].Wait().Get());
         }
-        PRINTMSG("{}", messageHandle.Get());
+        PRINTMSG("{}", messageHandle.Wait().Get());
 
         PRINTMSG("Secret Message: {}", secretMessageHandle.Wait().Get());
         PRINTMSG("Second Secret Message: {}", *secondSecretMessageHandle.Wait().Get());

--- a/Application/src/Application.cpp
+++ b/Application/src/Application.cpp
@@ -107,6 +107,7 @@ private:
     std::unique_ptr<std::string> modifiedMessage = std::make_unique<std::string>("The password is 54321");
     Agate::TaskHandle<std::string> secretMessageHandle;
     Agate::TaskHandle<std::shared_ptr<std::string>> secondSecretMessageHandle;
+    Agate::TaskHandle<int> iWillFail;
 public:
 
     void Attach() override
@@ -138,6 +139,11 @@ public:
             *result = *this->modifiedMessage;
             return std::move(result);
         });
+
+        iWillFail = Agate::TaskPool::Enqueue([]() -> int {
+            throw std::exception("I failed");
+            return 0;
+        });
     }
 
     void Detach() override
@@ -149,6 +155,12 @@ public:
 
         PRINTMSG("Secret Message: {}", secretMessageHandle.Wait().Get());
         PRINTMSG("Second Secret Message: {}", *secondSecretMessageHandle.Wait().Get());
+
+        if ((iWillFail.Status() & Agate::TaskStatus::Error) == Agate::TaskStatus::Error) {
+            PRINTMSG("iWillFail failed");
+        } else {
+            PRINTMSG("iWillFail did not fail");
+        }
     }
 
     void OnRender()override

--- a/Application/src/Application.cpp
+++ b/Application/src/Application.cpp
@@ -1,9 +1,13 @@
 
 #include "Agate.h"
+#include <array>
+#include <atomic>
 #include <chrono>
 #include <memory>
 #include <filesystem>
 #include <future>
+#include <string>
+
 class app : public Agate::EntryPoint {
 
 };

--- a/Application/src/Application.cpp
+++ b/Application/src/Application.cpp
@@ -19,6 +19,17 @@ public:
 
     void Detach() override
     {
+        {
+            auto taskFn = []() -> int {
+                PRINTMSG("Hello from Task Land");
+                return 0;
+            };
+            using FnType = decltype(taskFn);
+            using CleanType = std::decay_t<FnType>;
+            std::unique_ptr<Agate::Task> task = std::make_unique<Agate::QualifiedTask<CleanType>>(std::forward<FnType>(taskFn));
+            task->Run();
+        }
+
         PRINTMSG("Detach example layer");
     }
 

--- a/Application/src/Application.cpp
+++ b/Application/src/Application.cpp
@@ -99,6 +99,10 @@ private:;
     std::atomic<int> taskCounter{ 0 };
     std::array<Agate::TaskHandle<std::size_t>, 5> taskHandles;
     Agate::TaskHandle<std::string> messageHandle;
+    std::unique_ptr<std::string> originalMessage = std::make_unique<std::string>("The password is 12345");
+    std::unique_ptr<std::string> modifiedMessage = std::make_unique<std::string>("The password is 54321");
+    Agate::TaskHandle<std::string> secretMessageHandle;
+    Agate::TaskHandle<std::shared_ptr<std::string>> secondSecretMessageHandle;
 public:
 
     void Attach() override
@@ -114,6 +118,22 @@ public:
                 return this->taskCounter.load();
             });
         }
+
+        secretMessageHandle = Agate::TaskPool::Enqueue([this]() -> std::string {
+            std::this_thread::sleep_for(std::chrono::seconds(3));
+            return std::string(*this->originalMessage);
+        }).Then([this](std::string result) -> std::string {
+            result = *this->modifiedMessage;
+            return std::move(result);
+        });
+
+        secondSecretMessageHandle = Agate::TaskPool::Enqueue([this]() -> std::shared_ptr<std::string> {
+            std::this_thread::sleep_for(std::chrono::seconds(4));
+            return std::make_shared<std::string>(*this->originalMessage);
+        }).Then([this](std::shared_ptr<std::string> result) -> std::shared_ptr<std::string> {
+            *result = *this->modifiedMessage;
+            return std::move(result);
+        });
     }
 
     void Detach() override
@@ -122,6 +142,9 @@ public:
             PRINTMSG("Task {} finished in position {}", i, taskHandles[i].Wait().Get());
         }
         PRINTMSG("{}", messageHandle.Get());
+
+        PRINTMSG("Secret Message: {}", secretMessageHandle.Wait().Get());
+        PRINTMSG("Second Secret Message: {}", *secondSecretMessageHandle.Wait().Get());
     }
 
     void OnRender()override

--- a/Application/src/Application.cpp
+++ b/Application/src/Application.cpp
@@ -14,6 +14,7 @@ public:
     void Attach() override
     {
         PRINTMSG("Attached example layer");
+        PRINTMSG("Detected Process Concurrency: {}", Agate::ProcessConcurrency());
     }
 
     void Detach() override

--- a/Application/src/Application.cpp
+++ b/Application/src/Application.cpp
@@ -19,6 +19,8 @@ public:
 
     void Detach() override
     {
+
+        // Test making a task
         {
             auto taskFn = []() -> int {
                 PRINTMSG("Hello from Task Land");
@@ -28,6 +30,24 @@ public:
             using CleanType = std::decay_t<FnType>;
             std::unique_ptr<Agate::Task> task = std::make_unique<Agate::QualifiedTask<CleanType>>(std::forward<FnType>(taskFn));
             task->Run();
+        }
+
+        // Test making a task's callback and state
+        {
+            auto integerCallback = [](int result) -> void {
+                PRINTMSG("Callback land reports a result of {}", result);
+            };
+            using FnType = decltype(integerCallback);
+            using CleanType = std::decay_t<FnType>;
+            std::unique_ptr<Agate::TaskCallback<int>> callback 
+                    = std::make_unique<Agate::QualifiedCallback<int, CleanType>>(
+                std::forward<FnType>(integerCallback)
+            );
+            std::unique_ptr<Agate::QualifiedTaskState<int>> state
+                    = std::make_unique<Agate::QualifiedTaskState<int>>();
+            state->callback = std::move(callback);
+            state->result.emplace(1);
+            state->callback->Run(*(state->result));
         }
 
         PRINTMSG("Detach example layer");


### PR DESCRIPTION
Known Issues:
- `void` tasks currently will not build and require an explicit template instantiation override
- `std::unique_ptr<T>` may be the return type of a task, but attempting to attach a callback to such a task will result in a build failure
- The only straightforward way to mutate the result of a task in a callback is if the result is a raw pointer or `std::shared_ptr<T>`
- Currently does not build on clang due to use of `std::jthread`

# Add `TaskPool` API to the engine implemented in the `Agate/src/Agate/Async` directory.

This implementation currently spins up a thread pool with 2 less than the engine's best estimate for the amount of cores/hyperthreads available to the process (`std::thread::hardware_concurrency()` on Mac, `sched_getaffinity()` on Linux, and `GetProcessAffinityMask()` on Windows), or 1 at minimum. This is to try to maximize concurrency capability while avoiding thrashing and leaving some threads open for the render thread and main thread.

The task queue is currently a single queue owned by the task pool, but should later be replaced with per-worker queues with work stealing to avoid lock contention.

## Example Usage

```cpp
// The task pool needs to be statically initialized once
Agate::TaskPool::Initialize();

// Pass an invocable object and any arguments you want to Enqueue and it will give you a handle
Agate::TaskHandle<std::string> handle = Agate::TaskPool::Enqueue([](std::string message) -> std::string {
    std::this_thread::sleep(std::chrono::seconds(1));
    return message;
}, std::string{ "Hello from Task Land!" });

// The handle has a chainable `Wait()` member if you need to block until its completion, and a `Get()` 
// member to extract the task result
PRINTMSG("{}", handle.Wait().Get());
```

```cpp
// Use .Then() to pass a callback that the worker will pass the result to
auto myTask = Agate::TaskPool::Enqueue([]() -> Agate::ModelEditor {
    return Agate::ModelLoader::LoadModel("mymodel.obj");
}).Then([](Agate::ModelEditor& result) -> void {
    result.SetPosition(glm::vec3(0.0, 0.0, -10.0));
});

// ... Later
auto myModel = myTask.Wait().Get();
```