### PR TITLE
Replace `std::future` with `TaskPool` for asynchronous model loading (#77)

### DIFF
--- a/Agate/src/Agate/Async/TaskPool.h
+++ b/Agate/src/Agate/Async/TaskPool.h
@@ -130,6 +130,8 @@ ResultType TaskHandle<ResultType>::Get() {
 
     ResultType result = std::move(*(sharedState->result));
     sharedState->result.reset();
+    sharedState->status.store(TaskStatus::Extracted);
+
     return result;
 }
 

--- a/Agate/src/Agate/Async/TaskPool.h
+++ b/Agate/src/Agate/Async/TaskPool.h
@@ -121,16 +121,22 @@ TaskHandle<ResultType>& TaskHandle<ResultType>::Wait() {
 template<typename ResultType>
 ResultType TaskHandle<ResultType>::Get() {
 
-    // Critical error: Invalid access attempt
+    // Result not ready
     std::scoped_lock lock(sharedState->mutex);
     if (!sharedState->result.has_value() || Status() != TaskStatus::Done) {
         PRINTCRIT("Attempted to call `TaskHandle::Get` with an invalid result");
-        throw std::runtime_error("Invalid std::optional access attempt");
+        throw std::runtime_error("Invalid Task Extraction Attempt");
+    }
+
+    // Result already extracted
+    if ((sharedState->status.load() & TaskStatus::Extracted) == TaskStatus::Extracted) {
+        PRINTCRIT("Attempted to call `TaskHandle::Get` on an invalidated result due to prior extraction");
+        throw std::runtime_error("Invalid Task Extraction Attempt");
     }
 
     ResultType result = std::move(*(sharedState->result));
     sharedState->result.reset();
-    sharedState->status.store(TaskStatus::Extracted);
+    sharedState->status.store(sharedState->status.load() | TaskStatus::Extracted);
 
     return result;
 }

--- a/Agate/src/Agate/Async/TaskPool.h
+++ b/Agate/src/Agate/Async/TaskPool.h
@@ -273,6 +273,7 @@ public:
             } catch (const std::exception& exception) {
                 {
                     std::scoped_lock lock(state->mutex);
+                    PRINTERROR("Task threw an exception: {}", exception.what());
                     state->status.store(TaskStatus::Error);
                 }
                 state->condition.notify_all();

--- a/Agate/src/Agate/Async/TaskState.h
+++ b/Agate/src/Agate/Async/TaskState.h
@@ -21,14 +21,17 @@ namespace Agate {
  * @brief Descriptor for the current status of a task
  */
 enum class TaskStatus : std::uint32_t {
-    Ready               = 0,                        /*!< Task is in a queue and awaiting a worker to run it */
-    Working             = 1 << 0,                   /*!< Task is being run by a worker thread */
-    Done                = 1 << 1,                   /*!< Task has finished running and its result is ready for extraction */
-    CancelRequested     = 1 << 2,                   /*!< Task has received a cancellation request */
-    Cancelled           = 1 << 3,                   /*!< Task has stopped running due to being cancelled */
-    Error               = 1 << 4,                   /*!< Task has stopped running due to encountering an error state */
-    InCallback          = 1 << 5,                   /*!< Task has finished, but is executing a callback */
-    Terminal            = Error | Cancelled | Done  /*!< Task is in a terminal state - The task pool has discarded it */
+    NullState           = 0,
+    Ready               = 1 << 0,                   /*!< Task is in a queue and awaiting a worker to run it */
+    Working             = 1 << 1,                   /*!< Task is being run by a worker thread */
+    Done                = 1 << 2,                   /*!< Task has finished running and its result is ready for extraction */
+    Extracted           = 1 << 3,                   /*!< Task's result has been extracted */
+    CancelRequested     = 1 << 4,                   /*!< Task has received a cancellation request */
+    Cancelled           = 1 << 5,                   /*!< Task has stopped running due to being cancelled */
+    Error               = 1 << 6,                   /*!< Task has stopped running due to encountering an error state */
+    InCallback          = 1 << 7,                   /*!< Task has finished, but is executing a callback */
+    Terminal            = Error | Cancelled |       /*!< Task is in a terminal state - The task pool has discarded it */
+                          Done
 };
 
 constexpr inline TaskStatus operator|(TaskStatus left, TaskStatus right) {

--- a/Agate/src/Agate/Rendering/AssimpLoader.cpp
+++ b/Agate/src/Agate/Rendering/AssimpLoader.cpp
@@ -4,7 +4,6 @@
 #include "OpenGl/Texture.h"
 #include <assimp/postprocess.h>
 #include <assimp/scene.h>
-#include <future>
 #include <string>
 
 namespace {

--- a/Agate/src/Agate/Rendering/ModelLoader.cpp
+++ b/Agate/src/Agate/Rendering/ModelLoader.cpp
@@ -13,20 +13,17 @@ Agate::ModelLoader::~ModelLoader() = default;
 Agate::ModelLoader::ModelLoader(std::string const &path)
     : m_directory(extractDirectory(path)), m_path(path) {}
 
-std::future<std::unique_ptr<Agate::ModelEditor>> Agate::ModelLoader::LoadModel(const std::string &path) {
+Agate::TaskHandle<Agate::ModelEditor> Agate::ModelLoader::LoadModel(const std::string &path) {
 
-    return std::async(std::launch::async, [path]() {
-
-        std::unique_ptr<Agate::ModelLoader> loader = std::make_unique<Agate::AssimpLoader>(path);
+    return Agate::TaskPool::Enqueue([path]() -> Agate::ModelEditor {
         
+        std::unique_ptr<Agate::ModelLoader> loader = std::make_unique<Agate::AssimpLoader>(path);
         if (!loader->loadModel()) {
-            PRINTWARN("Failed to load model from {}", path);
-
-            return std::unique_ptr<Agate::ModelEditor>(nullptr);
+            throw std::runtime_error(fmt::format("Failed to load model from {}", path));
         }
         loader->m_meshes = loader->parseModel();
 
-        return std::make_unique<Agate::ModelEditor>(std::move(loader->m_path), std::move(loader->m_meshes));
+        return Agate::ModelEditor(std::move(loader->m_path), std::move(loader->m_meshes));
     });
 }
 

--- a/Agate/src/Agate/Rendering/ModelLoader.h
+++ b/Agate/src/Agate/Rendering/ModelLoader.h
@@ -1,11 +1,11 @@
 #ifndef AGATE_MODELLOADER_H
 #define AGATE_MODELLOADER_H
 
+#include "Agate/Async/TaskPool.h"
 #include "Mesh.h"
 #include "ModelEditor.h"
 #include "OpenGl/Shader.h"
 #include "OpenGl/Texture.h"
-#include <future>
 #include <memory>
 
 #define MAX_BONE_INFLUENCE 4
@@ -30,7 +30,7 @@ namespace Agate {
          * 
          * @param path Path to the model file
          */
-        static std::future<std::unique_ptr<ModelEditor>> LoadModel(std::string const &path);
+        static TaskHandle<ModelEditor> LoadModel(std::string const &path);
 
 protected:
 

--- a/Agate/src/Agate/Rendering/ModelLoader.h
+++ b/Agate/src/Agate/Rendering/ModelLoader.h
@@ -21,12 +21,13 @@ namespace Agate {
         std::string m_path;
 
         /**
-         * @brief Destructor - Blocks and waits for future completion if necessary
+         * @brief Destructor - Blocks and waits for completion if necessary
          */
         virtual ~ModelLoader();
 
         /**
-         * @brief Instructs the loader to start internally loading its model
+         * @brief Enqueues a task to load this loader's target and parses it into
+         *        an engine-ready format
          * 
          * @param path Path to the model file
          */
@@ -35,16 +36,9 @@ namespace Agate {
 protected:
 
         /**
-         * @brief Construct a ModelLoader and start loading a model on a background task.
+         * @brief Construct a ModelLoader for a target model file
          *
-         * Initializes model metadata and launches an asynchronous Assimp import using
-         * std::async. The returned aiScene* is stored in a std::future so the caller
-         * can continue without blocking.
-         *
-         * @param path     Filesystem path to the model file.
-         *
-         * @note The actual GPU/engine-side preparation is deferred until Draw() observes
-         *       the future is ready and calls prepareScene().
+         * @param path Filesystem path to the model file
          */ 
         ModelLoader(std::string const &path);
 

--- a/Application/src/Application.cpp
+++ b/Application/src/Application.cpp
@@ -60,6 +60,10 @@ public:
         if (modelHandle.Status() == Agate::TaskStatus::Done) {
             model = std::make_unique<Agate::ModelEditor>(std::move(modelHandle.Wait().Get()));
             model->LoadTextures();
+        } else if (modelHandle.Status() == Agate::TaskStatus::Error) {
+
+            // This will run every frame upon failure
+            PRINTCRIT("Failed to load model");
         }
 
         shader->Bind();
@@ -82,10 +86,10 @@ public:
     }
     virtual ~TemplayerEx()
     {
-        if (static_cast<uint32_t>(modelHandle.Status() & Agate::TaskStatus::Terminal) != static_cast<uint32_t>(0)) {
-            PRINTMSG("[TemplateLayer]: Waiting for pending model");
+        // Tasks not finished
+        if ((modelHandle.Status() & Agate::TaskStatus::Terminal) == static_cast<Agate::TaskStatus>(0)) {
+            PRINTMSG("[TemplateLayer]: Waiting for pending tasks to finish before destruction...");
             modelHandle.Wait();
-            model = std::make_unique<Agate::ModelEditor>(std::move(modelHandle.Get()));
         }
     }
 
@@ -195,6 +199,9 @@ public:
 
         if (consumed < produced && bulkHandles[consumed].Status() == Agate::TaskStatus::Done) {
             PRINTMSG("Consuming {}", bulkHandles[consumed++].Wait().Get());
+        } else if (consumed < produced && bulkHandles[consumed].Status() == Agate::TaskStatus::Error) {
+            PRINTWARN("Task {} failed", consumed);
+            consumed++;
         }
     };
 

--- a/Application/src/Application.cpp
+++ b/Application/src/Application.cpp
@@ -5,7 +5,6 @@
 #include <chrono>
 #include <memory>
 #include <filesystem>
-#include <future>
 #include <stdexcept>
 #include <string>
 
@@ -47,7 +46,7 @@ public:
         camera->setCameraPos({1.0f,1.0f,20.0f});
         camera->setCameraSpeed(10.f);
         model = nullptr;
-        pendingModel = Agate::ModelLoader::LoadModel(std::filesystem::path("Shaders/vokselia_spawn/vokselia_spawn.obj").generic_string());
+        modelHandle = Agate::ModelLoader::LoadModel(std::filesystem::path("Shaders/vokselia_spawn/vokselia_spawn.obj").generic_string());
     }
 
     void Detach() override
@@ -58,12 +57,9 @@ public:
     {
 
         // Poll for model completion until model is retrieved
-        if (pendingModel.valid()) {
-            const auto status = pendingModel.wait_for(std::chrono::seconds(0));
-            if (status == std::future_status::ready) {
-                model = pendingModel.get();
-                model->LoadTextures();
-            }
+        if (modelHandle.Status() == Agate::TaskStatus::Done) {
+            model = std::make_unique<Agate::ModelEditor>(std::move(modelHandle.Wait().Get()));
+            model->LoadTextures();
         }
 
         shader->Bind();
@@ -86,17 +82,17 @@ public:
     }
     virtual ~TemplayerEx()
     {
-        if (pendingModel.valid()) {
+        if (static_cast<uint32_t>(modelHandle.Status() & Agate::TaskStatus::Terminal) != static_cast<uint32_t>(0)) {
             PRINTMSG("[TemplateLayer]: Waiting for pending model");
-            pendingModel.wait();
-            model = pendingModel.get();
+            modelHandle.Wait();
+            model = std::make_unique<Agate::ModelEditor>(std::move(modelHandle.Get()));
         }
     }
 
     std::unique_ptr<Agate::Shader> shader;
     std::unique_ptr<Agate::Camera> camera;
     std::unique_ptr<Agate::ModelEditor> model;
-    std::future<std::unique_ptr<Agate::ModelEditor>> pendingModel;
+    Agate::TaskHandle<Agate::ModelEditor> modelHandle;
 };
 
 class TaskTestLayer : public Agate::Layer {


### PR DESCRIPTION
Changes asynchronous model loading via `ModelLoader::LoadModel` to utilize the `TaskPool` API instead of `std::async` and `std::future`.

Additionally makes a small improvement to `TaskHandle<T>::Get` to make it easier to know that the handle is invalidated after its result is extracted.

Resolves #77 