### PR TITLE
Replace global task queue with per-worker queues and work stealing (#78)

### DIFF
--- a/Agate/src/Agate/Async/Task.h
+++ b/Agate/src/Agate/Async/Task.h
@@ -26,6 +26,11 @@ public:
      * @brief Runs the task
      */
     virtual void Run() = 0;
+
+    /**
+     * @brief Cancels the task
+     */
+    virtual void Cancel() = 0;
 };
 
 /**
@@ -33,24 +38,32 @@ public:
  * 
  * @tparam FuncType Type of the invocable that runs the task
  */
-template<typename FuncType>
-    requires std::invocable<FuncType>
+template<typename FuncType, typename CancelType>
+    requires std::invocable<FuncType> && std::invocable<CancelType>
 class QualifiedTask : public Task {
 private:
     FuncType taskFn;
+    CancelType cancelFn;
 public:
 
     /**
      * @brief Forwarding constructor
      */
-    QualifiedTask(FuncType&& task)
-        : taskFn(std::forward<FuncType>(task)) {}
+    QualifiedTask(FuncType&& task, CancelType&& cancel)
+        : taskFn(std::forward<FuncType>(task)), cancelFn(std::forward<CancelType>(cancel)) {}
 
     /**
      * @brief Runs the task
      */
     virtual void Run() override {
         taskFn();
+    }
+
+    /**
+     * @brief Cancels the task
+     */
+    virtual void Cancel() override {
+        cancelFn();
     }
 };
 

--- a/Agate/src/Agate/Async/TaskPool.cpp
+++ b/Agate/src/Agate/Async/TaskPool.cpp
@@ -7,42 +7,24 @@ std::once_flag TaskPool::initializationFlag{};
 std::unique_ptr<Agate::TaskPool> TaskPool::instance = nullptr;
 
 TaskPool::TaskPool(unsigned int threadCount) {
+
+    // Workers must all be initialized before any workers are started
+    workers.resize(threadCount);
     for (std::size_t i = 0; i < threadCount; ++i) {
-        workers.emplace_back([this]() -> void {
-
-            while (true) {
-                std::unique_ptr<Task> currentTask;
-
-                // Wait until a task is ready, then take it from the queue and do it
-                {
-                    std::unique_lock lock(this->queueLock);
-                    this->queueCondition.wait(lock, [this]() -> bool {
-                        return this->shutdown.load() || !(this->taskQueue.empty());
-                    });
-
-                    // Shutdown - First worker to hit this will flush the queue
-                    if (this->shutdown.load()) {
-                        while (!this->taskQueue.empty()) {
-                            currentTask = std::move(this->taskQueue.front());
-                            this->taskQueue.pop();
-                            currentTask->Run();
-                        }
-                        return;
-                    }
-
-                    currentTask = std::move(this->taskQueue.front());
-                    this->taskQueue.pop();
-                }
-
-                currentTask->Run();
-            }
-        });
+        workers[i] = std::make_unique<TaskWorker>(i, std::span(workers));
+    }
+    for (std::size_t i = 0; i < workers.size(); ++i) {
+        workers[i]->Start();
     }
 }
 
 TaskPool::~TaskPool() {
     shutdown.store(true);
-    queueCondition.notify_all();
+    for (std::size_t i = 0; i < workers.size(); ++i) {
+        if (workers[i]) {
+            workers[i]->RequestStop();
+        }
+    }
 }
 
 void TaskPool::Initialize() {

--- a/Agate/src/Agate/Async/TaskPool.h
+++ b/Agate/src/Agate/Async/TaskPool.h
@@ -150,6 +150,12 @@ private:
 
     std::atomic<bool> shutdown = false;
     std::atomic<std::size_t> nextWorker = 0;
+
+    /** @note If this is allowed to be resized after initialization,
+     *        workers will have a dangling reference to the old vector
+     *        and will need to be refactored to use a different
+     *        reference type
+     */
     std::vector<std::unique_ptr<TaskWorker>> workers;
 
     /**

--- a/Agate/src/Agate/Async/TaskPool.h
+++ b/Agate/src/Agate/Async/TaskPool.h
@@ -134,7 +134,7 @@ ResultType TaskHandle<ResultType>::Get() {
 
 template<typename ResultType>
 void TaskHandle<ResultType>::Cancel() {
-    PRINTWARN("TaskHandle::Cancel not yet implemented");
+    sharedState->Cancel();
 }
 
 template<typename ResultType>
@@ -271,8 +271,12 @@ public:
             }
         };
 
+        auto cancel = [state]() -> void {
+            state->Cancel();
+        };
+
         // Package and enqueue task, then alert workers
-        std::unique_ptr<Task> packedTask = std::make_unique<QualifiedTask<decltype(wrappedTask)>>(std::move(wrappedTask));
+        std::unique_ptr<Task> packedTask = std::make_unique<QualifiedTask<decltype(wrappedTask), decltype(cancel)>>(std::move(wrappedTask), std::move(cancel));
         std::size_t targetIndex = instance->nextWorker.fetch_add(1, std::memory_order_relaxed) % instance->workers.size();
         instance->workers[targetIndex]->Push(std::move(packedTask));
         for (std::size_t i = 0; i < instance->workers.size(); ++i) {

--- a/Agate/src/Agate/Async/TaskPool.h
+++ b/Agate/src/Agate/Async/TaskPool.h
@@ -11,11 +11,10 @@
 #include "Agate/Core/Logger.h"
 #include "Task.h"
 #include "TaskState.h"
+#include "TaskWorker.h"
 #include <concepts>
 #include <memory>
-#include <queue>
 #include <stdexcept>
-#include <thread>
 #include <type_traits>
 #include <vector>
 
@@ -149,12 +148,9 @@ private:
     static std::once_flag initializationFlag;
     static std::unique_ptr<TaskPool> instance;
 
-    std::mutex queueLock;
-    std::condition_variable queueCondition;
-    std::queue<std::unique_ptr<Task>> taskQueue;
-
     std::atomic<bool> shutdown = false;
-    std::vector<std::jthread> workers;
+    std::atomic<std::size_t> nextWorker = 0;
+    std::vector<std::unique_ptr<TaskWorker>> workers;
 
     /**
      * @brief Singleton constructor - initializes worker threads
@@ -271,11 +267,11 @@ public:
 
         // Package and enqueue task, then alert workers
         std::unique_ptr<Task> packedTask = std::make_unique<QualifiedTask<decltype(wrappedTask)>>(std::move(wrappedTask));
-        {
-            std::scoped_lock lock(instance->queueLock);
-            instance->taskQueue.push(std::move(packedTask));
+        instance->workers[instance->nextWorker]->Push(std::move(packedTask));
+        for (std::size_t i = 0; i < instance->workers.size(); ++i) {
+            instance->workers[i]->Notify();
         }
-        instance->queueCondition.notify_one();
+        instance->nextWorker = (instance->nextWorker + 1) % instance->workers.size();
 
         return handle;
     }

--- a/Agate/src/Agate/Async/TaskPool.h
+++ b/Agate/src/Agate/Async/TaskPool.h
@@ -267,11 +267,11 @@ public:
 
         // Package and enqueue task, then alert workers
         std::unique_ptr<Task> packedTask = std::make_unique<QualifiedTask<decltype(wrappedTask)>>(std::move(wrappedTask));
-        instance->workers[instance->nextWorker]->Push(std::move(packedTask));
+        std::size_t targetIndex = instance->nextWorker.fetch_add(1, std::memory_order_relaxed) % instance->workers.size();
+        instance->workers[targetIndex]->Push(std::move(packedTask));
         for (std::size_t i = 0; i < instance->workers.size(); ++i) {
             instance->workers[i]->Notify();
         }
-        instance->nextWorker = (instance->nextWorker + 1) % instance->workers.size();
 
         return handle;
     }

--- a/Agate/src/Agate/Async/TaskState.h
+++ b/Agate/src/Agate/Async/TaskState.h
@@ -117,6 +117,13 @@ struct QualifiedTaskState {
     std::mutex mutex;
     std::condition_variable condition;
     std::atomic<TaskStatus> status = TaskStatus::Ready;
+
+    void Cancel() {
+        std::scoped_lock lock(mutex);
+        if (static_cast<std::uint32_t>(status.load() & TaskStatus::Terminal) != static_cast<std::uint32_t>(0)) {
+            status.store(TaskStatus::CancelRequested);
+        }
+    }
 };
 
 } // namespace Agate

--- a/Agate/src/Agate/Async/TaskWorker.cpp
+++ b/Agate/src/Agate/Async/TaskWorker.cpp
@@ -1,5 +1,4 @@
 #include "TaskWorker.h"
-#include <limits>
 #include <random>
 
 namespace {

--- a/Agate/src/Agate/Async/TaskWorker.cpp
+++ b/Agate/src/Agate/Async/TaskWorker.cpp
@@ -1,0 +1,118 @@
+#include "TaskWorker.h"
+#include <limits>
+#include <random>
+
+namespace {
+    constexpr unsigned int STEAL_ATTEMPTS = 3U;
+}
+
+namespace Agate {
+
+TaskWorker::TaskWorker(unsigned int id, std::span<std::unique_ptr<TaskWorker>> allWorkers)
+    : id(id), allWorkers(allWorkers) {
+
+}
+
+void TaskWorker::Start() {
+    worker = std::jthread(&TaskWorker::Run, this);
+}
+
+void TaskWorker::Push(std::unique_ptr<Task> task) {
+
+    {
+        std::scoped_lock lock(workerLock);
+        taskQueue.push_front(std::move(task));
+    }
+    workerCondition.notify_one();
+}
+
+void TaskWorker::Notify() {
+    workerCondition.notify_one();
+}
+
+void TaskWorker::RequestStop() {
+    worker.request_stop();
+}
+
+void TaskWorker::Run(std::stop_token stopToken) {
+
+    while (!stopToken.stop_requested()) {
+        std::unique_ptr<Task> currentTask;
+        {
+            std::unique_lock lock(workerLock);
+
+            // Find work
+            if (taskQueue.empty()) {
+                lock.unlock();
+                for (unsigned int i = 0; i < STEAL_ATTEMPTS; ++i) {
+                    currentTask = AttemptSteal();
+                    if (currentTask) {
+                        break;
+                    }
+                }
+            } else {
+                currentTask = std::move(taskQueue.front());
+                taskQueue.pop_front();
+            }
+
+            // No work available
+            if (!currentTask) {
+                lock.lock();
+                workerCondition.wait(lock, stopToken, [this]() -> bool {
+                    return !taskQueue.empty();
+                });
+                continue;
+            }
+        }
+        if (currentTask) {
+            currentTask->Run();
+        }
+    }
+
+    // Shutdown
+    while (true) {
+        std::unique_ptr<Task> currentTask;
+        {
+            std::unique_lock lock(workerLock);
+            if (taskQueue.empty()) {
+
+                return;
+            }
+            currentTask = std::move(taskQueue.front());
+            taskQueue.pop_front();
+        }
+        if (currentTask) {
+            currentTask->Run();
+        }
+    }
+}
+
+std::unique_ptr<Task> TaskWorker::AttemptSteal() {
+
+    // No workers to steal from
+    if (allWorkers.size() <= 1) {
+        return nullptr;
+    }
+
+    static thread_local std::mt19937 generator{ std::random_device{}() };
+    unsigned int victim = std::uniform_int_distribution<unsigned int>{ 0, static_cast<unsigned int>(allWorkers.size() - 1) }(generator);
+    while (victim == id) {
+        victim = std::uniform_int_distribution<unsigned int>{ 0, static_cast<unsigned int>(allWorkers.size() - 1) }(generator);
+    }
+
+    return allWorkers[victim]->ExtractStolenWork();
+}
+
+std::unique_ptr<Task> TaskWorker::ExtractStolenWork() {
+
+    std::unique_lock<std::mutex> lock(workerLock, std::try_to_lock);
+    if (!lock.owns_lock() || taskQueue.empty()) {
+        return nullptr;
+    }
+
+    std::unique_ptr<Task> stolenWork = std::move(taskQueue.back());
+    taskQueue.pop_back();
+    return stolenWork;
+}
+
+} // namespace Agate

--- a/Agate/src/Agate/Async/TaskWorker.cpp
+++ b/Agate/src/Agate/Async/TaskWorker.cpp
@@ -13,7 +13,9 @@ TaskWorker::TaskWorker(unsigned int id, std::span<std::unique_ptr<TaskWorker>> a
 }
 
 void TaskWorker::Start() {
-    worker = std::jthread(&TaskWorker::Run, this);
+    worker = std::jthread([this](std::stop_token stopToken) {
+        Run(stopToken);
+    });
 }
 
 void TaskWorker::Push(std::unique_ptr<Task> task) {

--- a/Agate/src/Agate/Async/TaskWorker.cpp
+++ b/Agate/src/Agate/Async/TaskWorker.cpp
@@ -41,8 +41,14 @@ void TaskWorker::Run(std::stop_token stopToken) {
         {
             std::unique_lock lock(workerLock);
 
-            // Find work
-            if (taskQueue.empty()) {
+            if (!taskQueue.empty()) {
+
+                // Local work
+                currentTask = std::move(taskQueue.front());
+                taskQueue.pop_front();
+            } else {
+
+                // No local work found
                 lock.unlock();
                 for (unsigned int i = 0; i < STEAL_ATTEMPTS; ++i) {
                     currentTask = AttemptSteal();
@@ -50,20 +56,18 @@ void TaskWorker::Run(std::stop_token stopToken) {
                         break;
                     }
                 }
-            } else {
-                currentTask = std::move(taskQueue.front());
-                taskQueue.pop_front();
-            }
 
-            // No work available
-            if (!currentTask) {
-                lock.lock();
-                workerCondition.wait(lock, stopToken, [this]() -> bool {
-                    return !taskQueue.empty();
-                });
-                continue;
+                // No work found
+                if (!currentTask) {
+                    lock.lock();
+                    workerCondition.wait(lock, stopToken, [this]() -> bool {
+                        return !taskQueue.empty();
+                    });
+                }
             }
         }
+
+        // Work found
         if (currentTask) {
             currentTask->Run();
         }

--- a/Agate/src/Agate/Async/TaskWorker.cpp
+++ b/Agate/src/Agate/Async/TaskWorker.cpp
@@ -89,6 +89,7 @@ void TaskWorker::Run(std::stop_token stopToken) {
             m_taskQueue.pop_front();
         }
         if (currentTask) {
+            currentTask->Cancel();
             currentTask->Run();
         }
     }

--- a/Agate/src/Agate/Async/TaskWorker.cpp
+++ b/Agate/src/Agate/Async/TaskWorker.cpp
@@ -28,6 +28,7 @@ void TaskWorker::Push(std::unique_ptr<Task> task) {
 }
 
 void TaskWorker::Notify() {
+    m_notified = true;
     m_workerCondition.notify_one();
 }
 
@@ -62,8 +63,9 @@ void TaskWorker::Run(std::stop_token stopToken) {
                 if (!currentTask) {
                     lock.lock();
                     m_workerCondition.wait(lock, stopToken, [this]() -> bool {
-                        return !m_taskQueue.empty();
+                        return !m_taskQueue.empty() || m_notified;
                     });
+                    m_notified = false;
                 }
             }
         }

--- a/Agate/src/Agate/Async/TaskWorker.cpp
+++ b/Agate/src/Agate/Async/TaskWorker.cpp
@@ -8,12 +8,12 @@ namespace {
 namespace Agate {
 
 TaskWorker::TaskWorker(unsigned int id, std::span<std::unique_ptr<TaskWorker>> allWorkers)
-    : id(id), allWorkers(allWorkers) {
+    : m_id(id), m_allWorkers(allWorkers) {
 
 }
 
 void TaskWorker::Start() {
-    worker = std::jthread([this](std::stop_token stopToken) {
+    m_worker = std::jthread([this](std::stop_token stopToken) {
         Run(stopToken);
     });
 }
@@ -21,18 +21,18 @@ void TaskWorker::Start() {
 void TaskWorker::Push(std::unique_ptr<Task> task) {
 
     {
-        std::scoped_lock lock(workerLock);
-        taskQueue.push_front(std::move(task));
+        std::scoped_lock lock(m_workerLock);
+        m_taskQueue.push_front(std::move(task));
     }
-    workerCondition.notify_one();
+    m_workerCondition.notify_one();
 }
 
 void TaskWorker::Notify() {
-    workerCondition.notify_one();
+    m_workerCondition.notify_one();
 }
 
 void TaskWorker::RequestStop() {
-    worker.request_stop();
+    m_worker.request_stop();
 }
 
 void TaskWorker::Run(std::stop_token stopToken) {
@@ -40,13 +40,13 @@ void TaskWorker::Run(std::stop_token stopToken) {
     while (!stopToken.stop_requested()) {
         std::unique_ptr<Task> currentTask;
         {
-            std::unique_lock lock(workerLock);
+            std::unique_lock lock(m_workerLock);
 
-            if (!taskQueue.empty()) {
+            if (!m_taskQueue.empty()) {
 
                 // Local work
-                currentTask = std::move(taskQueue.front());
-                taskQueue.pop_front();
+                currentTask = std::move(m_taskQueue.front());
+                m_taskQueue.pop_front();
             } else {
 
                 // No local work found
@@ -61,8 +61,8 @@ void TaskWorker::Run(std::stop_token stopToken) {
                 // No work found
                 if (!currentTask) {
                     lock.lock();
-                    workerCondition.wait(lock, stopToken, [this]() -> bool {
-                        return !taskQueue.empty();
+                    m_workerCondition.wait(lock, stopToken, [this]() -> bool {
+                        return !m_taskQueue.empty();
                     });
                 }
             }
@@ -78,13 +78,13 @@ void TaskWorker::Run(std::stop_token stopToken) {
     while (true) {
         std::unique_ptr<Task> currentTask;
         {
-            std::unique_lock lock(workerLock);
-            if (taskQueue.empty()) {
+            std::unique_lock lock(m_workerLock);
+            if (m_taskQueue.empty()) {
 
                 return;
             }
-            currentTask = std::move(taskQueue.front());
-            taskQueue.pop_front();
+            currentTask = std::move(m_taskQueue.front());
+            m_taskQueue.pop_front();
         }
         if (currentTask) {
             currentTask->Run();
@@ -95,28 +95,28 @@ void TaskWorker::Run(std::stop_token stopToken) {
 std::unique_ptr<Task> TaskWorker::AttemptSteal() {
 
     // No workers to steal from
-    if (allWorkers.size() <= 1) {
+    if (m_allWorkers.size() <= 1) {
         return nullptr;
     }
 
     static thread_local std::mt19937 generator{ std::random_device{}() };
-    unsigned int victim = std::uniform_int_distribution<unsigned int>{ 0, static_cast<unsigned int>(allWorkers.size() - 1) }(generator);
-    while (victim == id) {
-        victim = std::uniform_int_distribution<unsigned int>{ 0, static_cast<unsigned int>(allWorkers.size() - 1) }(generator);
+    unsigned int victim = std::uniform_int_distribution<unsigned int>{ 0, static_cast<unsigned int>(m_allWorkers.size() - 1) }(generator);
+    while (victim == m_id) {
+        victim = std::uniform_int_distribution<unsigned int>{ 0, static_cast<unsigned int>(m_allWorkers.size() - 1) }(generator);
     }
 
-    return allWorkers[victim]->ExtractStolenWork();
+    return m_allWorkers[victim]->ExtractStolenWork();
 }
 
 std::unique_ptr<Task> TaskWorker::ExtractStolenWork() {
 
-    std::unique_lock<std::mutex> lock(workerLock, std::try_to_lock);
-    if (!lock.owns_lock() || taskQueue.empty()) {
+    std::unique_lock<std::mutex> lock(m_workerLock, std::try_to_lock);
+    if (!lock.owns_lock() || m_taskQueue.empty()) {
         return nullptr;
     }
 
-    std::unique_ptr<Task> stolenWork = std::move(taskQueue.back());
-    taskQueue.pop_back();
+    std::unique_ptr<Task> stolenWork = std::move(m_taskQueue.back());
+    m_taskQueue.pop_back();
     return stolenWork;
 }
 

--- a/Agate/src/Agate/Async/TaskWorker.h
+++ b/Agate/src/Agate/Async/TaskWorker.h
@@ -1,0 +1,80 @@
+/**
+ * @brief Include file for the TaskWorker class
+ */
+
+#ifndef AGATE_TASKWORKER_H
+#define AGATE_TASKWORKER_H
+
+#include "Task.h"
+#include <condition_variable>
+#include <deque>
+#include <mutex>
+#include <span>
+#include <thread>
+
+namespace Agate {
+
+class TaskWorker {
+private:
+    unsigned int id;
+    std::span<std::unique_ptr<TaskWorker>> allWorkers;
+    std::deque<std::unique_ptr<Task>> taskQueue;
+    std::mutex workerLock;
+    std::condition_variable_any workerCondition;
+    std::jthread worker;
+public:
+
+    /**
+     * @brief Constructor - Initializes with an ID and reference to all
+     *        workers, then spins up the worker thread
+     * 
+     * @param id ID for this worker. Used to prevent self-stealing
+     * @param allWorkers Non-owning reference to all available workers for
+     *                   work stealing
+     */
+    TaskWorker(unsigned int id, std::span<std::unique_ptr<TaskWorker>> allWorkers);
+
+    /**
+     * @brief Launches the worker thread. Should only be called after all
+     *        workers have been initialized
+     */
+    void Start();
+
+    /**
+     * @brief Pushes a task to this worker's queue and notifies the worker
+     * 
+     * @param task Task to push to this worker's queue
+     */
+    void Push(std::unique_ptr<Task> task);
+
+    /**
+     * @brief Notify this worker that work has been received
+     */
+    void Notify();
+
+    /**
+     * @brief Requests this worker to stop its thread and cancel any remaining
+     *        work
+     */
+    void RequestStop();
+private:
+
+    /**
+     * @brief Runner for the worker thread
+     */
+    void Run(std::stop_token stopToken);
+
+    /**
+     * @brief Attempts to steal work from another worker
+     */
+    std::unique_ptr<Task> AttemptSteal();
+
+    /**
+     * @brief Extracts stealable work from this worker's queue, if available
+     */
+    std::unique_ptr<Task> ExtractStolenWork();
+};
+
+} // namespace Agate
+
+#endif

--- a/Agate/src/Agate/Async/TaskWorker.h
+++ b/Agate/src/Agate/Async/TaskWorker.h
@@ -18,6 +18,7 @@ namespace Agate {
 class TaskWorker {
 private:
     unsigned int m_id;
+    bool m_notified = false;
     std::span<std::unique_ptr<TaskWorker>> m_allWorkers;
     std::deque<std::unique_ptr<Task>> m_taskQueue;
     std::mutex m_workerLock;

--- a/Agate/src/Agate/Async/TaskWorker.h
+++ b/Agate/src/Agate/Async/TaskWorker.h
@@ -17,12 +17,12 @@ namespace Agate {
 
 class TaskWorker {
 private:
-    unsigned int id;
-    std::span<std::unique_ptr<TaskWorker>> allWorkers;
-    std::deque<std::unique_ptr<Task>> taskQueue;
-    std::mutex workerLock;
-    std::condition_variable_any workerCondition;
-    std::jthread worker;
+    unsigned int m_id;
+    std::span<std::unique_ptr<TaskWorker>> m_allWorkers;
+    std::deque<std::unique_ptr<Task>> m_taskQueue;
+    std::mutex m_workerLock;
+    std::condition_variable_any m_workerCondition;
+    std::jthread m_worker;
 public:
 
     /**

--- a/Agate/src/Agate/Async/TaskWorker.h
+++ b/Agate/src/Agate/Async/TaskWorker.h
@@ -8,6 +8,7 @@
 #include "Task.h"
 #include <condition_variable>
 #include <deque>
+#include <memory>
 #include <mutex>
 #include <span>
 #include <thread>

--- a/Application/src/Application.cpp
+++ b/Application/src/Application.cpp
@@ -170,6 +170,43 @@ public:
     }
 };
 
+class TaskPerFrameLayer : public Agate::Layer {
+private:
+    std::array<Agate::TaskHandle<int>, 1000> bulkHandles;
+    std::size_t produced = 0;
+    std::size_t consumed = 0;
+public:
+
+    void Attach() override
+    {
+
+    }
+
+    void Detach() override
+    {
+
+    }
+
+    void OnRender()override
+    {
+        if (produced < bulkHandles.size()) {
+            bulkHandles[produced++] = Agate::TaskPool::Enqueue([counter = produced]() -> int {
+                std::this_thread::sleep_for(std::chrono::milliseconds(250));
+                return counter;
+            });
+            PRINTMSG("Producing {}", produced - 1);
+        }
+
+        if (consumed < produced && bulkHandles[consumed].Status() == Agate::TaskStatus::Done) {
+            PRINTMSG("Consuming {}", bulkHandles[consumed++].Wait().Get());
+        }
+    };
+
+    void OnEvent(Agate::Event &e) override
+    {
+    }
+};
+
 Agate::EntryPoint* Agate::CreateEntryPoint()
 {
     auto Application = new app();
@@ -180,6 +217,7 @@ Agate::EntryPoint* Agate::CreateEntryPoint()
     Application->EmplaceLayer(example_layer);
     Application->EmplaceLayer(std::make_shared<TemplayerEx>());
     Application->EmplaceLayer(taskTestLayer);
+    Application->EmplaceLayer(std::make_shared<TaskPerFrameLayer>());
 
     Application->RemoveLayer(example_layer);
     Application->RemoveLayer(taskTestLayer);


### PR DESCRIPTION
This change should improve task pool performance by improving the throughput of `TaskPool::Enqueue` without harming the balancing of the distribution of tasks to workers:

- Workers now each have their own task queue and execute tasks in a last-in-first-out order to take advantage of the most recently added task having better odds of being cached.
- Tasks are distributed to workers in a simple round-robin fashion
- If a worker's queue is empty, it can attempt to steal work from another worker whose queue is not empty in order to ensure work remains well distributed

Resolves #78 