### PR TITLE
Add void instantiations for TaskPool (#79)

### DIFF
--- a/Agate/src/Agate/Async/TaskPool.h
+++ b/Agate/src/Agate/Async/TaskPool.h
@@ -133,9 +133,16 @@ ResultType TaskHandle<ResultType>::Get() {
 
     // Critical error: Invalid access attempt
     std::scoped_lock lock(sharedState->mutex);
-    if (!sharedState->result.has_value() || Status() != TaskStatus::Done) {
-        PRINTCRIT("Attempted to call `TaskHandle::Get` with an invalid result");
-        throw std::runtime_error("Invalid std::optional access attempt");
+    if constexpr (std::is_void_v<ResultType>) {
+        if (Status() != TaskStatus::Done) {
+            PRINTCRIT("Attempted to call `TaskHandle::Get` with an invalid result");
+            throw std::runtime_error("Invalid std::optional access attempt");
+        }
+    } else {
+        if (!sharedState->result.has_value() || Status() != TaskStatus::Done) {
+            PRINTCRIT("Attempted to call `TaskHandle::Get` with an invalid result");
+            throw std::runtime_error("Invalid std::optional access attempt");
+        }
     }
 
     if constexpr (std::is_void_v<ResultType>) {

--- a/Agate/src/Agate/Async/TaskPool.h
+++ b/Agate/src/Agate/Async/TaskPool.h
@@ -93,10 +93,21 @@ TaskHandle<ResultType>& TaskHandle<ResultType>::Then(FuncType&& callback) {
 
     std::scoped_lock lock(sharedState->mutex);
     bool statusDone = static_cast<std::uint32_t>(sharedState->status.load() & TaskStatus::Done) == static_cast<std::uint32_t>(TaskStatus::Done);
-    if (sharedState->result.has_value() && statusDone) {
-        callback(*(sharedState->result));
 
-        return *this;
+    // Task already done
+    if constexpr (std::is_void_v<ResultType>) {
+        // void specialization
+        if (statusDone) {
+            callback();
+
+            return *this;
+        }
+    } else {
+        if (sharedState->result.has_value() && statusDone) {
+            callback(*(sharedState->result));
+
+            return *this;
+        }
     }
     auto callbackPtr = std::make_unique<QualifiedCallback<ResultType, FuncType>>(std::forward<FuncType>(callback));
     sharedState->callback = std::move(callbackPtr);
@@ -127,9 +138,13 @@ ResultType TaskHandle<ResultType>::Get() {
         throw std::runtime_error("Invalid std::optional access attempt");
     }
 
-    ResultType result = std::move(*(sharedState->result));
-    sharedState->result.reset();
-    return result;
+    if constexpr (std::is_void_v<ResultType>) {
+        return;
+    } else {
+        ResultType result = std::move(*(sharedState->result));
+        sharedState->result.reset();
+        return result;
+    }
 }
 
 template<typename ResultType>
@@ -249,17 +264,32 @@ public:
             try {
 
                 state->status.store(TaskStatus::Working);
-                ResultType result = task();
 
-                // Safely store result
-                {
-                    std::scoped_lock lock(state->mutex);
-                    state->result = std::move(result);
-                    state->status.store(TaskStatus::Done);
-                    if (state->callback) {
-                        state->callback->Run(*(state->result));
+                if constexpr (std::is_void_v<ResultType>) {
+                    task();
+
+                    // Safely store result
+                    {
+                        std::scoped_lock lock(state->mutex);
+                        state->status.store(TaskStatus::Done);
+                        if (state->callback) {
+                            state->callback->Run();
+                        }
+                    }
+                } else {
+                    ResultType result = task();
+
+                    // Safely store result
+                    {
+                        std::scoped_lock lock(state->mutex);
+                        state->result = std::move(result);
+                        state->status.store(TaskStatus::Done);
+                        if (state->callback) {
+                            state->callback->Run(*(state->result));
+                        }
                     }
                 }
+
                 state->condition.notify_all();
 
             } catch (const std::exception& exception) {

--- a/Agate/src/Agate/Async/TaskState.h
+++ b/Agate/src/Agate/Async/TaskState.h
@@ -14,7 +14,7 @@
 #include <optional>
 #include <variant>
 #include <type_traits>
-
+#include <utility>
 
 namespace Agate {
 

--- a/Agate/src/Agate/Async/TaskState.h
+++ b/Agate/src/Agate/Async/TaskState.h
@@ -12,6 +12,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <variant>
 #include <type_traits>
 
 
@@ -76,7 +77,7 @@ public:
  * @tparam FuncType Type of the callback invocable
  */
 template<typename ResultType, typename FuncType>
-    requires std::invocable<FuncType, ResultType>
+    requires std::invocable<FuncType, ResultType> || (std::is_void_v<ResultType> && std::invocable<FuncType>)
 class QualifiedCallback : public TaskCallback<ResultType> {
 private:
     FuncType callback;
@@ -98,6 +99,46 @@ public:
     }
 };
 
+/*
+    Void specializations for callback types
+ */
+
+template<>
+class TaskCallback<void> {
+public:
+    /**
+     * @brief Virtual destructor for subclasses
+     */
+    virtual ~TaskCallback() = default;
+
+    /**
+     * @brief Invokes the callback with the result of the task
+     */
+    virtual void Run() = 0;
+};
+
+template<typename FuncType>
+    requires std::invocable<FuncType>
+class QualifiedCallback<void, FuncType> : public TaskCallback<void> {
+        FuncType callback;
+public:
+
+    /**
+     * @brief Forwarding constructor
+     * 
+     * @param callback Invocable to pass task result to when the callback is run
+     */
+    QualifiedCallback(FuncType&& callback)
+        : callback(std::forward<FuncType>(callback)) {}
+    
+    /**
+     * @brief Invokes the callback with the result of the task
+     */
+    virtual void Run() override {
+        callback();
+    }
+};
+
 /**
  * @brief Shared state wrapper for qualified tasks
  * 
@@ -111,7 +152,13 @@ public:
 template<typename ResultType>
 struct QualifiedTaskState {
 
-    std::optional<ResultType> result;
+    using ResultMemberType = std::conditional_t<
+        std::is_void_v<ResultType>,
+        std::monostate,
+        std::optional<ResultType>
+    >;
+
+    ResultMemberType result;
     std::unique_ptr<TaskCallback<ResultType>> callback;
 
     std::mutex mutex;

--- a/Application/src/Application.cpp
+++ b/Application/src/Application.cpp
@@ -109,6 +109,7 @@ private:
     Agate::TaskHandle<std::string> secretMessageHandle;
     Agate::TaskHandle<std::shared_ptr<std::string>> secondSecretMessageHandle;
     Agate::TaskHandle<int> iWillFail;
+    Agate::TaskHandle<void> delayedMessageHandle;
 public:
 
     void Attach() override
@@ -141,6 +142,12 @@ public:
         iWillFail = Agate::TaskPool::Enqueue([]() -> int {
             throw std::runtime_error("I failed");
             return 0;
+        });
+        delayedMessageHandle = Agate::TaskPool::Enqueue([]() -> void {
+            std::this_thread::sleep_for(std::chrono::seconds(10));
+            PRINTMSG("This message was delayed by 10 seconds");
+        }).Then([]() -> void {
+            PRINTMSG("This message was printed in a callback after the delayed message");
         });
     }
 

--- a/Application/src/Application.cpp
+++ b/Application/src/Application.cpp
@@ -166,6 +166,8 @@ public:
         } else {
             PRINTMSG("iWillFail did not fail");
         }
+
+        delayedMessageHandle.Wait();
     }
 
     void OnRender()override


### PR DESCRIPTION
The TaskPool system is currently unable to accept tasks that return `void`. This PR adds conditional compilation and explicit `void` instantiations in order to allow tasks of type `void`.

Resolves #79 